### PR TITLE
feat: remove extension ability to modify set values

### DIFF
--- a/src/example/empty.rs
+++ b/src/example/empty.rs
@@ -15,8 +15,8 @@ impl SettingsModel for EmptySetting {
         "v1"
     }
 
-    fn set(_current_value: Option<Self>, target: Self) -> Result<Self> {
-        Ok(target)
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        Ok(())
     }
 
     fn generate(
@@ -26,8 +26,8 @@ impl SettingsModel for EmptySetting {
         Ok(GenerateResult::Complete(Self))
     }
 
-    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<bool> {
-        Ok(true)
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/src/migrate/linear/interface.rs
+++ b/src/migrate/linear/interface.rs
@@ -47,8 +47,8 @@ pub struct LinearMigrator;
 /// #         "v1"
 /// #     }
 /// #
-/// #     fn set(_current_value: Option<Self>, target: Self) -> Result<Self> {
-/// #         Ok(target)
+/// #     fn set(_current_value: Option<Self>, target: Self) -> Result<()> {
+/// #         Ok(())
 /// #     }
 /// #
 /// #     fn generate(
@@ -58,8 +58,8 @@ pub struct LinearMigrator;
 /// #         Ok(GenerateResult::Complete(Self::default()))
 /// #     }
 /// #
-/// #     fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<bool> {
-/// #         Ok(true)
+/// #     fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+/// #         Ok(())
 /// #     }
 /// # }
 /// #
@@ -71,8 +71,8 @@ pub struct LinearMigrator;
 /// #         "v2"
 /// #     }
 /// #
-/// #     fn set(_current_value: Option<Self>, target: Self) -> Result<Self> {
-/// #         Ok(target)
+/// #     fn set(_current_value: Option<Self>, target: Self) -> Result<()> {
+/// #         Ok(())
 /// #     }
 /// #
 /// #     fn generate(
@@ -82,8 +82,8 @@ pub struct LinearMigrator;
 /// #         Ok(GenerateResult::Complete(Self::default()))
 /// #     }
 /// #
-/// #     fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<bool> {
-/// #         Ok(true)
+/// #     fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+/// #         Ok(())
 /// #     }
 /// # }
 /// impl LinearlyMigrateable for ScoreV1 {

--- a/src/migrate/linear/mod.rs
+++ b/src/migrate/linear/mod.rs
@@ -400,8 +400,8 @@ mod test {
                     // We allow any transition from current value to target, so we don't need the current value
                     _current_value: Option<Self>,
                     _target: Self,
-                ) -> Result<Self, Infallible> {
-                    Ok(Self::new())
+                ) -> Result<(), Infallible> {
+                    Ok(())
                 }
 
                 fn generate(
@@ -415,8 +415,8 @@ mod test {
                 fn validate(
                     _value: Self,
                     _validated_settings: Option<serde_json::Value>,
-                ) -> Result<bool, Infallible> {
-                    Ok(true)
+                ) -> Result<(), Infallible> {
+                    Ok(())
                 }
             }
 

--- a/src/migrate/mod.rs
+++ b/src/migrate/mod.rs
@@ -125,7 +125,7 @@ impl SettingsModel for NoMigration {
         )
     }
 
-    fn set(_current_value: Option<Self>, _target: Self) -> Result<Self, Self::ErrorKind> {
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<(), Self::ErrorKind> {
         unimplemented!(
             "`NoMigration` used as a marker type. Its settings model should never be used."
         )
@@ -143,7 +143,7 @@ impl SettingsModel for NoMigration {
     fn validate(
         _value: Self,
         _validated_settings: Option<serde_json::Value>,
-    ) -> Result<bool, Self::ErrorKind> {
+    ) -> Result<(), Self::ErrorKind> {
         unimplemented!(
             "`NoMigration` used as a marker type. Its settings model should never be used."
         )

--- a/src/model/erased.rs
+++ b/src/model/erased.rs
@@ -42,7 +42,7 @@ pub trait TypeErasedModel: Debug {
         &self,
         current: Option<serde_json::Value>,
         target: serde_json::Value,
-    ) -> Result<serde_json::Value, BottlerocketSettingError>;
+    ) -> Result<(), BottlerocketSettingError>;
 
     /// Generates default values at system start.
     ///
@@ -64,7 +64,7 @@ pub trait TypeErasedModel: Debug {
         &self,
         value: serde_json::Value,
         validated_settings: Option<serde_json::Value>,
-    ) -> Result<bool, BottlerocketSettingError>;
+    ) -> Result<(), BottlerocketSettingError>;
 
     /// Parses a JSON value into the underlying model type, then erases its type via the `Any` trait.
     ///
@@ -99,7 +99,7 @@ impl<T: SettingsModel + 'static> TypeErasedModel for BottlerocketSetting<T> {
         &self,
         current: Option<serde_json::Value>,
         target: serde_json::Value,
-    ) -> Result<serde_json::Value, BottlerocketSettingError> {
+    ) -> Result<(), BottlerocketSettingError> {
         debug!(
             current_value = current.as_ref().map(|v| v.to_string()),
             target_value = target.to_string(),
@@ -126,12 +126,6 @@ impl<T: SettingsModel + 'static> TypeErasedModel for BottlerocketSetting<T> {
             .map_err(Into::into)
             .context(error::SetSettingSnafu {
                 version: T::get_version(),
-            })
-            .and_then(|retval| {
-                serde_json::to_value(retval).context(error::SerializeResultSnafu {
-                    version: T::get_version(),
-                    operation: "set",
-                })
             })
     }
 
@@ -176,7 +170,7 @@ impl<T: SettingsModel + 'static> TypeErasedModel for BottlerocketSetting<T> {
         &self,
         value: serde_json::Value,
         validated_settings: Option<serde_json::Value>,
-    ) -> Result<bool, BottlerocketSettingError> {
+    ) -> Result<(), BottlerocketSettingError> {
         debug!(
             %value,
             validated_settings = validated_settings.as_ref().map(|v| v.to_string()),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -38,9 +38,9 @@ pub use error::BottlerocketSettingError;
 ///         "v1"
 ///     }
 ///
-///     fn set(current_value: Option<Self>, target: Self) -> Result<Self> {
+///     fn set(current_value: Option<Self>, target: Self) -> Result<()> {
 ///         // Perform any additional validations of the new value here...
-///         Ok(target)
+///         Ok(())
 ///     }
 ///
 ///     fn generate(
@@ -51,9 +51,9 @@ pub use error::BottlerocketSettingError;
 ///         Ok(GenerateResult::Complete(MySettings::default()))
 ///     }
 ///
-///     fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<bool> {
+///     fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
 ///         // Cross-validation of new values can occur against other settings here...
-///         Ok(true)
+///         Ok(())
 ///     }
 /// }
 ///
@@ -76,10 +76,8 @@ pub trait SettingsModel: Sized + Serialize + DeserializeOwned + Debug {
 
     /// Determines whether this setting can be set to the `target` value, given its current value.
     ///
-    /// The returned value is what is ultimately set in the settings datastore. While this leaves
-    /// room for the extension to modify the value that is stored, this should be done cautiously
-    /// so as not to confuse users.
-    fn set(current_value: Option<Self>, target: Self) -> Result<Self, Self::ErrorKind>;
+    /// Returns an error if the value is rejected.
+    fn set(current_value: Option<Self>, target: Self) -> Result<(), Self::ErrorKind>;
 
     /// Generates default values at system start.
     ///
@@ -99,7 +97,7 @@ pub trait SettingsModel: Sized + Serialize + DeserializeOwned + Debug {
     fn validate(
         _value: Self,
         _validated_settings: Option<serde_json::Value>,
-    ) -> Result<bool, Self::ErrorKind>;
+    ) -> Result<(), Self::ErrorKind>;
 }
 
 /// This struct wraps [`SettingsModel`]s in a referencable object which is passed to the

--- a/tests/colliding_versions/mod.rs
+++ b/tests/colliding_versions/mod.rs
@@ -41,7 +41,7 @@ impl SettingsModel for ModelA {
         "v1"
     }
 
-    fn set(_: Option<Self>, _: Self) -> Result<Self> {
+    fn set(_: Option<Self>, _: Self) -> Result<()> {
         unimplemented!()
     }
 
@@ -52,7 +52,7 @@ impl SettingsModel for ModelA {
         unimplemented!()
     }
 
-    fn validate(_: Self, _: Option<serde_json::Value>) -> Result<bool> {
+    fn validate(_: Self, _: Option<serde_json::Value>) -> Result<()> {
         unimplemented!()
     }
 }
@@ -79,7 +79,7 @@ impl SettingsModel for ModelB {
         "v1"
     }
 
-    fn set(_: Option<Self>, _: Self) -> Result<Self> {
+    fn set(_: Option<Self>, _: Self) -> Result<()> {
         unimplemented!()
     }
 
@@ -90,7 +90,7 @@ impl SettingsModel for ModelB {
         unimplemented!()
     }
 
-    fn validate(_: Self, _: Option<serde_json::Value>) -> Result<bool> {
+    fn validate(_: Self, _: Option<serde_json::Value>) -> Result<()> {
         unimplemented!()
     }
 }

--- a/tests/migration_validation/mod.rs
+++ b/tests/migration_validation/mod.rs
@@ -18,7 +18,7 @@ macro_rules! define_model {
                 $version
             }
 
-            fn set(_: Option<Self>, _: Self) -> Result<Self> {
+            fn set(_: Option<Self>, _: Self) -> Result<()> {
                 unimplemented!()
             }
 
@@ -29,7 +29,7 @@ macro_rules! define_model {
                 unimplemented!()
             }
 
-            fn validate(_: Self, _: Option<serde_json::Value>) -> Result<bool> {
+            fn validate(_: Self, _: Option<serde_json::Value>) -> Result<()> {
                 unimplemented!()
             }
         }

--- a/tests/motd/v1.rs
+++ b/tests/motd/v1.rs
@@ -22,10 +22,10 @@ impl SettingsModel for MotdV1 {
     fn set(
         // We allow any transition from current value to target, so we don't need the current value
         _current_value: Option<Self>,
-        target: Self,
-    ) -> Result<Self> {
+        _target: Self,
+    ) -> Result<()> {
         // Allow anything that parses as MotdV1
-        Ok(target)
+        Ok(())
     }
 
     fn generate(
@@ -39,9 +39,9 @@ impl SettingsModel for MotdV1 {
         ))
     }
 
-    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<bool> {
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
         // No need to do any additional validation, any MotdV1 is acceptable
-        Ok(true)
+        Ok(())
     }
 }
 
@@ -72,12 +72,9 @@ fn test_motdv1_set_success() {
     // Then that input is successfully set.
     vec![json!("Hello!"), json!("")]
         .into_iter()
-        .for_each(|value| {
-            assert_eq!(
-                set_cli(motd_settings_extension(), "v1", value.clone()).unwrap(),
-                value
-            )
-        });
+        .for_each(
+            |value| assert!(set_cli(motd_settings_extension(), "v1", value.clone()).is_ok(),),
+        );
 }
 
 #[test]
@@ -105,10 +102,7 @@ fn test_motdv1_generate() {
 fn test_motdv1_validate() {
     // When validate is called on motdv1,
     // it is successful for any value that parses
-    assert_eq!(
-        validate_cli(motd_settings_extension(), "v1", json!("test"), None).unwrap(),
-        json!(true),
-    );
+    assert!(validate_cli(motd_settings_extension(), "v1", json!("test"), None).is_ok(),);
 }
 
 #[test]

--- a/tests/motd/v2.rs
+++ b/tests/motd/v2.rs
@@ -19,10 +19,10 @@ impl SettingsModel for MotdV2 {
     fn set(
         // We allow any transition from current value to target, so we don't need the current value
         _current_value: Option<Self>,
-        target: Self,
-    ) -> anyhow::Result<Self> {
+        _target: Self,
+    ) -> anyhow::Result<()> {
         // Allow anything that parses as MotdV2
-        Ok(target)
+        Ok(())
     }
 
     fn generate(
@@ -36,16 +36,15 @@ impl SettingsModel for MotdV2 {
         ))
     }
 
-    fn validate(
-        value: Self,
-        _validated_settings: Option<serde_json::Value>,
-    ) -> anyhow::Result<bool> {
+    fn validate(value: Self, _validated_settings: Option<serde_json::Value>) -> anyhow::Result<()> {
         let Self(inner_strings) = value;
 
         // No whitespace allowed in any of the substrings
-        Ok(!inner_strings
+        anyhow::ensure!(!inner_strings
             .iter()
-            .any(|i| i.contains(char::is_whitespace)))
+            .any(|i| i.contains(char::is_whitespace)),);
+
+        Ok(())
     }
 }
 
@@ -80,12 +79,7 @@ fn test_motdv2_set_success() {
         json!([]),
     ]
     .into_iter()
-    .for_each(|value| {
-        assert_eq!(
-            set_cli(motd_settings_extension(), "v2", value.clone()).unwrap(),
-            value
-        )
-    });
+    .for_each(|value| assert!(set_cli(motd_settings_extension(), "v2", value.clone()).is_ok()));
 }
 
 #[test]

--- a/tests/sample_extensions.rs
+++ b/tests/sample_extensions.rs
@@ -28,7 +28,7 @@ mod helpers {
         extension: SettingsExtension<Mi, Mo>,
         version: &str,
         value: serde_json::Value,
-    ) -> Result<serde_json::Value>
+    ) -> Result<()>
     where
         Mi: Migrator<ModelKind = Mo>,
         Mo: AsTypeErasedModel,
@@ -44,8 +44,9 @@ mod helpers {
                 value.to_string().as_str(),
             ])
             .context("Failed to run settings extension CLI")
-            .and_then(|s| {
-                serde_json::from_str(s.as_str()).context("Failed to parse CLI result as JSON")
+            .map(|s| {
+                assert!(s.is_empty());
+                ()
             })
     }
 
@@ -98,7 +99,7 @@ mod helpers {
         version: &str,
         value: serde_json::Value,
         required_settings: Option<serde_json::Value>,
-    ) -> Result<serde_json::Value>
+    ) -> Result<()>
     where
         Mi: Migrator<ModelKind = Mo>,
         Mo: AsTypeErasedModel,
@@ -126,8 +127,9 @@ mod helpers {
         extension
             .try_run_with_args(args)
             .context("Failed to run settings extension CLI")
-            .and_then(|s| {
-                serde_json::from_str(s.as_str()).context("Failed to parse CLI result as JSON")
+            .map(|s| {
+                assert!(s.is_empty());
+                ()
             })
     }
 


### PR DESCRIPTION
**Issues**:
Closes: #1

*Description of changes:*
* `set` operations now only validate incoming values, they have no ability to modify them.
* `validate` operation API reworked to be consistent with `set`
* All protocol output now goes to stdout, reserving stderr for logging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
