### PR TITLE
chore: break circular dependency for crates.io

### DIFF
--- a/bottlerocket-template-helper/Cargo.toml
+++ b/bottlerocket-template-helper/Cargo.toml
@@ -22,4 +22,4 @@ syn = { version = "1", default-features = false, features = ["full", "parsing", 
 
 [dev-dependencies]
 anyhow = "1"
-bottlerocket-settings-sdk = { path = "../bottlerocket-settings-sdk", version = "0.1" }
+bottlerocket-settings-sdk = { path = "../bottlerocket-settings-sdk" }

--- a/deny.toml
+++ b/deny.toml
@@ -35,4 +35,10 @@ wildcards = "deny"
 skip = [
     # snafu is using an older version of syn   
     { name = "syn", version = "1" },
+
+    # bottlerocket-settings-sdk and bottlerocket-template-helper are circularly dependent,
+    # bottlerocket-template-helper has a dev-dependency on the settings-sdk for tests.
+    # In order to bootstrap releases on crates.io, we must drop the `version` requirement the first
+    # time that we publish bottlerocket-template-helper
+    { name = "bottlerocket-template-helper", version = "*" }
 ]


### PR DESCRIPTION
Crates with circular dependencies like the one expressed between bottlerocket-settings-sdk and bottlerocket-template-helper must be released to crates.io via a bootstrap process which prevents cargo from enforcing that dependencies are already present on crates.io.

A similar process was used to bootstrap crates like serde, which has the same dependency layout as these crates.


I will revert this commit once we have published `0.1.0` to crates.io.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
