### PR TITLE
refactor: migrate from clap to argh

### DIFF
--- a/bottlerocket-settings-sdk/Cargo.toml
+++ b/bottlerocket-settings-sdk/Cargo.toml
@@ -7,8 +7,8 @@ repository = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
 readme = "../README.md"
 
 [dependencies]
+argh = "0.1"
 bottlerocket-template-helper = { path = "../bottlerocket-template-helper", version = "0.1.0-alpha" }
-clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 snafu = "0.7"

--- a/bottlerocket-settings-sdk/Cargo.toml
+++ b/bottlerocket-settings-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bottlerocket-settings-sdk"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 license = "Apache-2.0 OR MIT"
 edition = "2021"
 repository = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"

--- a/bottlerocket-settings-sdk/src/cli/mod.rs
+++ b/bottlerocket-settings-sdk/src/cli/mod.rs
@@ -5,20 +5,20 @@
 #![allow(missing_docs)]
 pub mod proto1;
 
+use argh::FromArgs;
 use std::fmt::Display;
 
-use clap::{Parser, Subcommand};
-
-#[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
-#[command(propagate_version = true)]
+/// Top-level CLI command.
+#[derive(FromArgs, Debug)]
 pub struct Cli {
-    /// The Bottlerocket Settings CLI protocol to use
-    #[command(subcommand)]
+    /// the Bottlerocket Settings CLI protocol to use
+    #[argh(subcommand)]
     pub protocol: Protocol,
 }
 
-#[derive(Subcommand, Debug)]
+/// The CLI protocol to use when invoking the extension.
+#[derive(FromArgs, Debug)]
+#[argh(subcommand)]
 pub enum Protocol {
     #[cfg(feature = "proto1")]
     /// Settings extension protocol 1

--- a/bottlerocket-settings-sdk/tests/sample_extensions.rs
+++ b/bottlerocket-settings-sdk/tests/sample_extensions.rs
@@ -179,12 +179,11 @@ mod helpers {
         let args = vec![
             "extension",
             "proto1",
-            "migrate",
+            "flood-migrate",
             "--value",
             &value,
             "--from-version",
             from_version,
-            "--flood",
         ];
 
         extension

--- a/deny.toml
+++ b/deny.toml
@@ -13,7 +13,7 @@ confidence-threshold = 0.93
 allow = [
     "Apache-2.0",
     # "BSD-2-Clause",
-    # "BSD-3-Clause",
+    "BSD-3-Clause",
     "BSL-1.0",
     # "CC0-1.0",
     # "ISC",


### PR DESCRIPTION
**Issue #:**
Closes #23

**Description of changes:**
```
    refactor: migrate from clap to argh
    
    Bottlerocket already uses argh for argument parsing. Reducing the
    variety of crates contributes to more efficient builds.
    
    argh doesn't support mutually exclusive options, so flood migrations
    have been split into their own command.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
