### PR TITLE
docs: clarify CLI-visible help text

### DIFF
--- a/bottlerocket-settings-sdk/src/cli/mod.rs
+++ b/bottlerocket-settings-sdk/src/cli/mod.rs
@@ -8,7 +8,7 @@ pub mod proto1;
 use argh::FromArgs;
 use std::fmt::Display;
 
-/// Top-level CLI command.
+/// Provides a CLI interface to the settings extension.
 #[derive(FromArgs, Debug)]
 pub struct Cli {
     /// the Bottlerocket Settings CLI protocol to use


### PR DESCRIPTION
**Description of changes:**
This docstring is visible when reading the `--help` output of extension CLIs, when I assumed it was not being used by `argh`. This makes it a bit more reasonable as user-facing output.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
