### PR TITLE
chore: update deny.toml to version 2

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,10 +1,5 @@
 [licenses]
-unlicensed = "deny"
-
-# Deny licenses unless they are specifically listed here
-copyleft = "deny"
-allow-osi-fsf-free = "neither"
-default = "deny"
+version = 2
 
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.93


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Move to "version = 2" format and drop deprecated keys to avoid warnings from newer versions of cargo deny.

See https://github.com/bottlerocket-os/bottlerocket/pull/3885 for prior art.

**Terms of contribution:**
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
