### PR TITLE
feat: add a new type for the kubernetes hostname override mode

### DIFF
--- a/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
+++ b/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
@@ -1411,3 +1411,32 @@ mod test_kubernetes_memory_manager_policy {
         }
     }
 }
+
+/// KubernetesHostnameOverrideSource represents a string that is a valid hostname override source.
+/// This is used to configure different node name modes for Kubernetes nodes.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Scalar)]
+pub enum KubernetesHostnameOverrideSource {
+    #[serde(rename = "private-dns-name")]
+    PrivateDNSName,
+    #[serde(rename = "instance-id")]
+    InstanceID,
+}
+
+#[cfg(test)]
+mod test_hostname_override_source {
+    use crate::KubernetesHostnameOverrideSource;
+
+    #[test]
+    fn good_override() {
+        for ok in &["private-dns-name", "instance-id"] {
+            KubernetesHostnameOverrideSource::try_from(*ok).unwrap();
+        }
+    }
+
+    #[test]
+    fn bad_override() {
+        for err in &["", "invalid", &"a".repeat(64)] {
+            KubernetesHostnameOverrideSource::try_from(*err).unwrap_err();
+        }
+    }
+}

--- a/bottlerocket-settings-models/settings-models/src/kubernetes/mod.rs
+++ b/bottlerocket-settings-models/settings-models/src/kubernetes/mod.rs
@@ -3,11 +3,13 @@ mod de;
 
 use self::de::deserialize_node_taints;
 use bottlerocket_model_derive::model;
-use bottlerocket_modeled_types::KubernetesCPUManagerPolicyOption;
 use bottlerocket_modeled_types::KubernetesEvictionKey;
 use bottlerocket_modeled_types::KubernetesMemoryManagerPolicy;
 use bottlerocket_modeled_types::KubernetesMemoryReservation;
 use bottlerocket_modeled_types::NonNegativeInteger;
+use bottlerocket_modeled_types::{
+    KubernetesCPUManagerPolicyOption, KubernetesHostnameOverrideSource,
+};
 use std::collections::HashMap;
 use std::net::IpAddr;
 
@@ -94,6 +96,7 @@ pub struct KubernetesSettingsV1 {
     pod_infra_container_image: SingleLineString,
     // Generated in `aws-k8s-1.26*` variants only
     hostname_override: ValidLinuxHostname,
+    hostname_override_source: KubernetesHostnameOverrideSource,
     // Generated in `k8s-1.25+` variants only
     seccomp_default: bool,
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Adds a new type to be used when configuring the hostname override mode.


```
[root@admin]# apiclient set settings.kubernetes.hostname-override-source=asd
Failed to change settings: Failed PATCH request to '/settings/keypair?tx=apiclient-set-0PV6YalhON4ZW9bb': Status 400 when PATCHing /settings/keypair?tx=apiclient-set-0PV6YalhON4ZW9bb: Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error during deserialization: unknown variant `asd`, expected `private-dns-name` or `instance-id` at line 1 column 47

[root@admin]# apiclient set settings.kubernetes.hostname-override-source=private-dns-name

```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
