### PR TITLE
feat: add settings models for bootstrap commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     # These will eventually live in the kit workspaces that own the related software
     "bottlerocket-settings-models/settings-extensions/autoscaling",
     "bottlerocket-settings-models/settings-extensions/aws",
+    "bottlerocket-settings-models/settings-extensions/bootstrap-commands",
     "bottlerocket-settings-models/settings-extensions/bootstrap-containers",
     "bottlerocket-settings-models/settings-extensions/cloudformation",
     "bottlerocket-settings-models/settings-extensions/container-registry",
@@ -63,6 +64,7 @@ bottlerocket-string-impls-for = { path = "./bottlerocket-settings-models/string-
 ## Settings Extensions
 settings-extension-autoscaling = { path = "./bottlerocket-settings-models/settings-extensions/autoscaling", version = "0.1" }
 settings-extension-aws = { path = "./bottlerocket-settings-models/settings-extensions/aws", version = "0.1" }
+settings-extension-bootstrap-commands = { path = "./bottlerocket-settings-models/settings-extensions/bootstrap-commands", version = "0.1" }
 settings-extension-bootstrap-containers = { path = "./bottlerocket-settings-models/settings-extensions/bootstrap-containers", version = "0.1" }
 settings-extension-cloudformation = { path = "./bottlerocket-settings-models/settings-extensions/cloudformation", version = "0.1" }
 settings-extension-container-registry = { path = "./bottlerocket-settings-models/settings-extensions/container-registry", version = "0.1" }

--- a/bottlerocket-settings-models/modeled-types/src/lib.rs
+++ b/bottlerocket-settings-models/modeled-types/src/lib.rs
@@ -71,8 +71,8 @@ pub mod error {
         #[snafu(display("Invalid Kubernetes authentication mode '{}'", input))]
         InvalidAuthenticationMode { input: String },
 
-        #[snafu(display("Invalid bootstrap container mode '{}'", input))]
-        InvalidBootstrapContainerMode { input: String },
+        #[snafu(display("Invalid bootstrap mode '{}'", input))]
+        InvalidBootstrapMode { input: String },
 
         #[snafu(display("Given invalid cluster name '{}': {}", name, msg))]
         InvalidClusterName { name: String, msg: String },
@@ -85,6 +85,9 @@ pub mod error {
 
         #[snafu(display("Invalid Linux lockdown mode '{}'", input))]
         InvalidLockdown { input: String },
+
+        #[snafu(display("Invalid Bottlerocket API Command '{:?}'", input))]
+        InvalidCommand { input: Vec<String> },
 
         #[snafu(display("Invalid sysctl key '{}': {}", input, msg))]
         InvalidSysctlKey { input: String, msg: String },

--- a/bottlerocket-settings-models/settings-extensions/bootstrap-commands/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/bootstrap-commands/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "settings-extension-bootstrap-commands"
+version = "0.1.0"
+authors = ["Piyush Jena <jepiyush@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+bottlerocket-modeled-types.workspace = true
+bottlerocket-model-derive.workspace = true
+bottlerocket-settings-sdk.workspace = true
+env_logger.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+snafu.workspace = true
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/bootstrap-commands/bootstrap-commands.toml
+++ b/bottlerocket-settings-models/settings-extensions/bootstrap-commands/bootstrap-commands.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]

--- a/bottlerocket-settings-models/settings-extensions/bootstrap-commands/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/bootstrap-commands/src/lib.rs
@@ -1,0 +1,148 @@
+//! Settings related to bootstrap commands.
+use bottlerocket_model_derive::model;
+use bottlerocket_modeled_types::{ApiclientCommand, BootstrapMode, Identifier};
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{collections::BTreeMap, convert::Infallible};
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BootstrapCommandsSettingsV1 {
+    pub bootstrap_commands: BTreeMap<Identifier, BootstrapCommand>,
+}
+
+// Custom serializer/deserializer added to maintain backwards
+// compatibility with models created prior to settings extensions.
+impl Serialize for BootstrapCommandsSettingsV1 {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.bootstrap_commands.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for BootstrapCommandsSettingsV1 {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bootstrap_commands = BTreeMap::deserialize(deserializer)?;
+        Ok(Self { bootstrap_commands })
+    }
+}
+
+#[model(impl_default = true)]
+struct BootstrapCommand {
+    commands: Vec<ApiclientCommand>,
+    mode: BootstrapMode,
+    essential: bool,
+}
+
+impl SettingsModel for BootstrapCommandsSettingsV1 {
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // Set anything that parses as BootstrapCommandsSettingsV1.
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(
+            existing_partial.unwrap_or_default(),
+        ))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        // Validate anything that parses as BootstrapCommandsSettingsV1.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test_bootstrap_command {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_generate_bootstrap_command_settings() {
+        let generated = BootstrapCommandsSettingsV1::generate(None, None).unwrap();
+
+        assert_eq!(
+            generated,
+            GenerateResult::Complete(BootstrapCommandsSettingsV1 {
+                bootstrap_commands: BTreeMap::new(),
+            })
+        )
+    }
+
+    #[test]
+    fn test_serde_bootstrap_command() {
+        let test_json = json!({
+            "mybootstrap": {
+                "commands": [ ["apiclient", "motd=hello"], ],
+                "mode": "once",
+                "essential": true,
+            }
+        });
+
+        let bootstrap_commands: BootstrapCommandsSettingsV1 =
+            serde_json::from_value(test_json.clone()).unwrap();
+
+        let mut expected_bootstrap_commands: BTreeMap<Identifier, BootstrapCommand> =
+            BTreeMap::new();
+        expected_bootstrap_commands.insert(
+            Identifier::try_from("mybootstrap").unwrap(),
+            BootstrapCommand {
+                commands: Some(vec![ApiclientCommand::try_from(vec![
+                    "apiclient".to_string(),
+                    "motd=hello".to_string(),
+                ])
+                .unwrap()]),
+                mode: Some(BootstrapMode::try_from("once").unwrap()),
+                essential: Some(true),
+            },
+        );
+
+        assert_eq!(
+            bootstrap_commands,
+            BootstrapCommandsSettingsV1 {
+                bootstrap_commands: expected_bootstrap_commands
+            }
+        );
+
+        let serialized_json: serde_json::Value = serde_json::to_string(&bootstrap_commands)
+            .map(|s| serde_json::from_str(&s).unwrap())
+            .unwrap();
+
+        assert_eq!(serialized_json, test_json);
+    }
+
+    #[test]
+    fn test_serde_invalid_bootstrap_command() {
+        let test_err_json = json!({
+            "mybootstrap1": {
+                "commands": [ ["/usr/bin/touch", "helloworld"], ],
+                "mode": "once",
+                "essential": true,
+            }
+        });
+
+        let bootstrap_commands_err: std::result::Result<
+            BootstrapCommandsSettingsV1,
+            serde_json::Error,
+        > = serde_json::from_value(test_err_json.clone());
+
+        // This has invalid command. It should fail.
+        assert!(bootstrap_commands_err.is_err());
+    }
+}
+
+type Result<T> = std::result::Result<T, Infallible>;

--- a/bottlerocket-settings-models/settings-extensions/bootstrap-commands/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/bootstrap-commands/src/main.rs
@@ -1,0 +1,20 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_bootstrap_commands::BootstrapCommandsSettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("bootstrap-commands")
+        .with_models(vec![
+            BottlerocketSetting::<BootstrapCommandsSettingsV1>::model(),
+        ])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/bottlerocket-settings-models/settings-extensions/bootstrap-containers/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/bootstrap-containers/src/lib.rs
@@ -1,6 +1,6 @@
 //! Settings related to bootstrap containers.
 use bottlerocket_model_derive::model;
-use bottlerocket_modeled_types::{BootstrapContainerMode, Identifier, Url, ValidBase64};
+use bottlerocket_modeled_types::{BootstrapMode, Identifier, Url, ValidBase64};
 use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{collections::HashMap, convert::Infallible};
@@ -36,7 +36,7 @@ impl<'de> Deserialize<'de> for BootstrapContainersSettingsV1 {
 #[model(impl_default = true)]
 struct BootstrapContainer {
     source: Url,
-    mode: BootstrapContainerMode,
+    mode: BootstrapMode,
     user_data: ValidBase64,
     essential: bool,
 }
@@ -115,7 +115,7 @@ mod test {
                     )
                     .unwrap(),
                 ),
-                mode: Some(BootstrapContainerMode::try_from("once").unwrap()),
+                mode: Some(BootstrapMode::try_from("once").unwrap()),
                 user_data: Some(ValidBase64::try_from("dXNlcmRhdGE=").unwrap()),
                 essential: Some(true),
             },

--- a/bottlerocket-settings-models/settings-models/Cargo.toml
+++ b/bottlerocket-settings-models/settings-models/Cargo.toml
@@ -27,6 +27,7 @@ toml.workspace = true
 # settings extensions
 settings-extension-autoscaling.workspace = true
 settings-extension-aws.workspace = true
+settings-extension-bootstrap-commands.workspace = true
 settings-extension-bootstrap-containers.workspace = true
 settings-extension-cloudformation.workspace = true
 settings-extension-container-registry.workspace = true

--- a/bottlerocket-settings-models/settings-models/src/lib.rs
+++ b/bottlerocket-settings-models/settings-models/src/lib.rs
@@ -27,6 +27,7 @@ pub use bottlerocket_string_impls_for as string_impls_for;
 pub use crate::boot::BootSettingsV1;
 pub use settings_extension_autoscaling::{self, AutoScalingSettingsV1};
 pub use settings_extension_aws::{self, AwsSettingsV1};
+pub use settings_extension_bootstrap_commands::{self, BootstrapCommandsSettingsV1};
 pub use settings_extension_bootstrap_containers::{self, BootstrapContainersSettingsV1};
 pub use settings_extension_cloudformation::{self, CloudFormationSettingsV1};
 pub use settings_extension_container_registry::{self, RegistrySettingsV1};


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR contains the following changes:
1. settings sdk changes for supporting settings.bootstrap-commands in bottlerocket.
2. Modified deny.toml to get a successful build. BSD-2 license and multiple versions of crates were allowed. Currently the repository doesn't have a Cargo.lock file which means there is no control over the dependency tree. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

The change in deny.toml will be done in a separate commit after the code review and before merging.
