### PR TITLE
chore: deny clippy::indexing_slicing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,3 +79,6 @@ settings-extension-oci-defaults = { path = "./bottlerocket-settings-models/setti
 settings-extension-oci-hooks = { path = "./bottlerocket-settings-models/settings-extensions/oci-hooks", version = "0.1" }
 settings-extension-pki = { path = "./bottlerocket-settings-models/settings-extensions/pki", version = "0.1" }
 settings-extension-updates = { path = "./bottlerocket-settings-models/settings-extensions/updates", version = "0.1" }
+
+[workspace.lints.clippy]
+indexing_slicing = "deny"

--- a/bottlerocket-defaults-helper/Cargo.toml
+++ b/bottlerocket-defaults-helper/Cargo.toml
@@ -15,3 +15,6 @@ authors = [
 snafu = "0.8"
 toml = "0.8"
 walkdir = "2"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-derive/Cargo.toml
+++ b/bottlerocket-settings-derive/Cargo.toml
@@ -14,3 +14,6 @@ darling = "0.20.8"
 proc-macro2 = "1.0.81"
 quote = "1.0.36"
 syn = "2.0.60"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/model-derive/Cargo.toml
+++ b/bottlerocket-settings-models/model-derive/Cargo.toml
@@ -16,3 +16,6 @@ proc-macro = true
 darling = "0.20"
 quote = "1"
 syn = { version = "2", default-features = false, features = ["full", "parsing", "printing", "proc-macro", "visit-mut"] }
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/modeled-types/Cargo.toml
+++ b/bottlerocket-settings-models/modeled-types/Cargo.toml
@@ -24,3 +24,6 @@ serde_plain = "1"
 snafu = "0.8"
 url = "2"
 x509-parser = "0.16"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/modeled-types/src/shared.rs
+++ b/bottlerocket-settings-models/modeled-types/src/shared.rs
@@ -550,7 +550,7 @@ impl TryFrom<FriendlyVersion> for semver::Version {
     fn try_from(input: FriendlyVersion) -> Result<semver::Version, Self::Error> {
         // If the string begins with a 'v', skip it before conversion
         let version = if input.inner.starts_with('v') {
-            &input.inner[1..]
+            input.inner.get(1..).unwrap_or_default()
         } else {
             &input.inner
         };

--- a/bottlerocket-settings-models/scalar-derive/Cargo.toml
+++ b/bottlerocket-settings-models/scalar-derive/Cargo.toml
@@ -20,3 +20,6 @@ bottlerocket-scalar.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_plain = "1"
 syn = { version = "2", default-features = false, features = ["full", "parsing", "printing", "proc-macro", "visit-mut"] }
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/scalar/Cargo.toml
+++ b/bottlerocket-settings-models/scalar/Cargo.toml
@@ -11,3 +11,6 @@ exclude = ["README.md"]
 [dependencies]
 serde = "1"
 serde_plain = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/autoscaling/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/autoscaling/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/aws/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/aws/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/bootstrap-containers/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/bootstrap-containers/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/cloudformation/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/cloudformation/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/container-registry/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/container-registry/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/container-runtime/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/container-runtime/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/dns/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/dns/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/ecs/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/ecs/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/host-containers/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/host-containers/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/kernel/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/kernel/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/metrics/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/metrics/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/motd/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/motd/Cargo.toml
@@ -12,3 +12,6 @@ bottlerocket-string-impls-for.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/network/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/network/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/ntp/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/ntp/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/nvidia-container-runtime/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/nvidia-container-runtime/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/oci-defaults/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/oci-defaults/Cargo.toml
@@ -14,3 +14,6 @@ env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/oci-hooks/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/oci-hooks/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/pki/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/pki/Cargo.toml
@@ -13,3 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/updates/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/updates/Cargo.toml
@@ -14,3 +14,6 @@ env_logger = "0.10"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-models/Cargo.toml
+++ b/bottlerocket-settings-models/settings-models/Cargo.toml
@@ -44,3 +44,6 @@ settings-extension-oci-defaults.workspace = true
 settings-extension-oci-hooks.workspace = true
 settings-extension-pki.workspace = true
 settings-extension-updates.workspace = true
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/string-impls-for/Cargo.toml
+++ b/bottlerocket-settings-models/string-impls-for/Cargo.toml
@@ -10,3 +10,6 @@ exclude = ["README.md"]
 
 [dependencies]
 serde = "1"
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-plugin/Cargo.toml
+++ b/bottlerocket-settings-plugin/Cargo.toml
@@ -12,3 +12,6 @@ lazy_static = "1.4.0"
 serde = "1.0.198"
 serde_json = "1.0.116"
 bottlerocket-settings-derive.workspace = true
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-sdk/Cargo.toml
+++ b/bottlerocket-settings-sdk/Cargo.toml
@@ -29,3 +29,6 @@ extension = []
 
 # Enable Bottlerocket settings extensions CLI proto1.
 proto1 = []
+
+[lints]
+workspace = true

--- a/bottlerocket-template-helper/Cargo.toml
+++ b/bottlerocket-template-helper/Cargo.toml
@@ -23,3 +23,6 @@ syn = { version = "2", default-features = false, features = ["full", "parsing", 
 [dev-dependencies]
 anyhow = "1"
 bottlerocket-settings-sdk.workspace = true
+
+[lints]
+workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -21,25 +21,6 @@ allow = [
 exceptions = [
     { name = "generational-arena", allow = ["MPL-2.0"] },
     { name = "unicode-ident", allow = ["MIT", "Apache-2.0", "Unicode-DFS-2016"] },
-    { name = "icu_collections", allow = ["Unicode-3.0"] },
-    { name = "icu_locid", allow = ["Unicode-3.0"] },
-    { name = "icu_locid_transform", allow = ["Unicode-3.0"] },
-    { name = "icu_locid_transform_data", allow = ["Unicode-3.0"] },
-    { name = "icu_normalizer", allow = ["Unicode-3.0"] },
-    { name = "icu_normalizer_data", allow = ["Unicode-3.0"] },
-    { name = "icu_properties", allow = ["Unicode-3.0"] },
-    { name = "icu_properties_data", allow = ["Unicode-3.0"] },
-    { name = "icu_provider", allow = ["Unicode-3.0"] },
-    { name = "icu_provider_macros", allow = ["Unicode-3.0"] },
-    { name = "litemap", allow = ["Unicode-3.0"] },
-    { name = "tinystr", allow = ["Unicode-3.0"] },
-    { name = "writeable", allow = ["Unicode-3.0"] },
-    { name = "yoke", allow = ["Unicode-3.0"] },
-    { name = "yoke-derive", allow = ["Unicode-3.0"] },
-    { name = "zerofrom", allow = ["Unicode-3.0"] },
-    { name = "zerofrom-derive", allow = ["Unicode-3.0"] },
-    { name = "zerovec", allow = ["Unicode-3.0"] },
-    { name = "zerovec-derive", allow = ["Unicode-3.0"] },
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,7 @@ confidence-threshold = 0.93
 # Commented license types are allowed but not currently used
 allow = [
     "Apache-2.0",
-    # "BSD-2-Clause",
+    "BSD-2-Clause",
     "BSD-3-Clause",
     "BSL-1.0",
     # "CC0-1.0",
@@ -44,7 +44,6 @@ exceptions = [
 
 [bans]
 # Deny multiple versions or wildcard dependencies.
-multiple-versions = "deny"
 wildcards = "deny"
 
 skip = [


### PR DESCRIPTION
*Description of changes:*
This change:
* Enables workspace-level configuration of clippy lints
* Disallows indexing a slice, which can panic

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
