### PR TITLE
feat: add nvidia shared GPU settings to k8s model 

### DIFF
--- a/bottlerocket-settings-models/modeled-types/src/shared.rs
+++ b/bottlerocket-settings-models/modeled-types/src/shared.rs
@@ -1181,6 +1181,47 @@ mod test_positive_integer {
 
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
+/// Input value that needs to be a positive integer, but should not be greater
+/// than an i32::MAX.
+#[derive(Clone, Debug, PartialEq, Scalar)]
+pub struct PositiveInteger {
+    inner: i32,
+}
+
+impl Validate for PositiveInteger {
+    fn validate<I: Into<i32>>(input: I) -> Result<PositiveInteger, ValidationError> {
+        let inner: i32 = input.into();
+        if inner < 1 {
+            Err(ValidationError::new(
+                "number must be great than or equal to 1",
+            ))
+        } else {
+            Ok(Self { inner })
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_nonzero_integer {
+    use super::PositiveInteger;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn valid_positive_integer() {
+        assert!(PositiveInteger::try_from(1).is_ok());
+        assert!(PositiveInteger::try_from(i32::MAX).is_ok());
+        assert!(PositiveInteger::try_from(42).is_ok());
+    }
+
+    #[test]
+    fn invalid_positive_integer() {
+        assert!(PositiveInteger::try_from(i32::MIN).is_err());
+        assert!(PositiveInteger::try_from(-1).is_err());
+        assert!(PositiveInteger::try_from(0).is_err());
+    }
+}
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
 /// KernelCpuSetValue represents a string that contains a valid Kernel CpuSet Value from
 /// here: https://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS. This matches the
 /// logic from https://github.com/kubernetes/utils/blob/d93618cff8a22d3aea7bf78d9d528fd859720c2d/cpuset/cpuset.go#L203

--- a/bottlerocket-settings-models/settings-models/src/kubernetes/mod.rs
+++ b/bottlerocket-settings-models/settings-models/src/kubernetes/mod.rs
@@ -24,6 +24,12 @@ use bottlerocket_modeled_types::{
     TopologyManagerScope, Url, ValidBase64, ValidLinuxHostname,
 };
 
+// Feature flags
+#[cfg(feature = "nvidia-device-plugin")]
+pub const NVIDIA_DEVICE_PLUGIN_FEATURE_ENABLED: bool = true;
+#[cfg(not(feature = "nvidia-device-plugin"))]
+pub const NVIDIA_DEVICE_PLUGIN_FEATURE_ENABLED: bool = false;
+
 // Kubernetes static pod manifest settings
 #[model]
 pub struct StaticPod {

--- a/bottlerocket-settings-models/settings-models/src/lib.rs
+++ b/bottlerocket-settings-models/settings-models/src/lib.rs
@@ -15,7 +15,7 @@ settings structures that helpfully validate inputs on deserialize.
 */
 
 mod boot;
-mod kubernetes;
+pub mod kubernetes;
 
 // Expose types for creating new settings structs
 pub use bottlerocket_model_derive as model_derive;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR introduces two new fields within the `NvidiaDevicePluginSettings` structure: `max_sharing_per_gpu` and `rename_shared_gpu`. These new fields are for managing the timeslicing capabilities of Nvidia GPUs.

Setting `max_sharing_per_gpu` to **1** deactivates time-slicing, effectively disabling GPU sharing. Conversely, a value greater than **1** activates time-slicing, resulting in the creation of the specified number of GPU replicas.

The `rename_shared_gpu` field dictates the naming convention for shared GPU resources. A `false` value retains the original GPU name, while `true` triggers a renaming process, appending `.shared` to the GPU identifier. For instance, enabling this feature would transform `nvidia.com/gpu` to `nvidia.com/gpu.shared`.

By contributing this pull request, I grant permission to use, modify, replicate, and distribute my submission, in accordance with your preferred terms.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice."
