### PR TITLE
models: skip serializing credential provider fields if they are None

### DIFF
--- a/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
+++ b/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
@@ -1308,7 +1308,9 @@ type EnvVarMap = HashMap<SingleLineString, SingleLineString>;
 pub struct CredentialProvider {
     enabled: bool,
     image_patterns: Vec<SingleLineString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     cache_duration: Option<KubernetesDurationValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     environment: Option<EnvVarMap>,
 }
 


### PR DESCRIPTION
*Issue #, if available:*

Fixes the first issue seen in [#4135](https://github.com/bottlerocket-os/bottlerocket/issues/4135) ([comment](https://github.com/bottlerocket-os/bottlerocket/issues/4135#issuecomment-2278495919))

*Description of changes:*

Skips serializing the `Option` fields of the kubernetes `CredentialProvider` modeled type if they are `None`.

*Testing:*

Launched an instance, and verified that setting the user data provided by the user in [#4135](https://github.com/bottlerocket-os/bottlerocket/issues/4135) does not result in an error:

```
bash-5.2# cat <<EOF > /local/user-data-defaults.toml
> [settings.kubernetes.credential-providers.ecr-credential-provider]
enabled = true
cache-duration = "30m"
image-patterns = [
  "*.dkr.ecr.*.amazonaws.com"
]
> EOF
bash-5.2# early-boot-config
[2024-08-09T21:44:05Z INFO  early_boot_config] early-boot-config started
[2024-08-09T21:44:05Z INFO  early_boot_config] Gathering user data providers
[2024-08-09T21:44:05Z INFO  early_boot_config] Provider '10-local-defaults': [2024-08-09T21:44:05Z INFO  early_boot_config_provider::provider] '/local/user-data-defaults.toml' exists, using it
[2024-08-09T21:44:05Z INFO  early_boot_config] Found user data via user data from /local/user-data-defaults.toml, sending to API
[2024-08-09T21:44:05Z INFO  early_boot_config] Provider '20-local-user-data': [2024-08-09T21:44:05Z INFO  early_boot_config_provider::provider] /var/lib/bottlerocket/user-data.toml does not exist, not using it
[2024-08-09T21:44:05Z INFO  early_boot_config] No user data found via /usr/libexec/early-boot-config/data-providers.d/20-local-user-data
[2024-08-09T21:44:05Z INFO  early_boot_config] Provider '30-ec2-identity-doc': [2024-08-09T21:44:05Z INFO  ec2_identity_doc_user_data_provider] Using IMDS for region
[2024-08-09T21:44:05Z INFO  early_boot_config] Provider '30-ec2-identity-doc': [2024-08-09T21:44:05Z INFO  imdsclient] Received dynamic/instance-identity/document
[2024-08-09T21:44:05Z INFO  early_boot_config] Found user data via EC2 instance identity document, sending to API
[2024-08-09T21:44:05Z INFO  early_boot_config] Provider '40-ec2-imds': [2024-08-09T21:44:05Z INFO  ec2_imds_user_data_provider] Fetching user data from IMDS
[2024-08-09T21:44:05Z INFO  early_boot_config] Provider '40-ec2-imds': [2024-08-09T21:44:05Z INFO  imdsclient] Received user-data
[2024-08-09T21:44:05Z INFO  early_boot_config] Found user data via EC2 IMDS, sending to API
[2024-08-09T21:44:05Z INFO  early_boot_config] Provider '99-local-overrides': [2024-08-09T21:44:05Z INFO  early_boot_config_provider::provider] /local/user-data-overrides.toml does not exist, not using it
[2024-08-09T21:44:05Z INFO  early_boot_config] No user data found via /usr/libexec/early-boot-config/data-providers.d/99-local-overrides
[2024-08-09T21:44:05Z WARN  early_boot_config] Failed to create marker file /var/lib/bottlerocket/early-boot-config.ran, may unexpectedly run again: Permission denied (os error 13)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
