### PR TITLE
ci: enable commitlint for PRs

### DIFF
--- a/.commitlint.config.mjs
+++ b/.commitlint.config.mjs
@@ -1,0 +1,42 @@
+/* [commitlint](https://github.com/conventional-changelog/commitlint) configuration */
+import {
+    RuleConfigSeverity,
+} from '@commitlint/types';
+
+export default {
+    parserPreset: 'conventional-changelog-conventionalcommits',
+    rules: {
+        'header-max-length': [RuleConfigSeverity.Error, 'always', 72], // Header should be 72 characters or shorter
+        'header-trim': [RuleConfigSeverity.Error, 'always'], // No leading/trailing whitespace in header
+        'subject-empty': [RuleConfigSeverity.Error, 'never'], // No empty subject
+        'subject-case': [ // Subject line should be lowercase
+            RuleConfigSeverity.Error,
+            'never',
+            ['sentence-case', 'start-case', 'pascal-case', 'upper-case']],
+        'subject-full-stop': [RuleConfigSeverity.Error, 'never'], // No full-stop at end of subject
+        'body-max-line-length': [RuleConfigSeverity.Error, 'always', 72], // Body lines should be 72 characteres or shorter
+        'body-leading-blank': [RuleConfigSeverity.Error, 'always'], // Empty line before body
+        'type-empty': [RuleConfigSeverity.Error, 'never'], // Commit type must be present
+        'type-case': [RuleConfigSeverity.Error, 'always', 'lower-case'], // Commit type should be lowercase
+        'type-enum': [ // Commit type allowlist
+            RuleConfigSeverity.Error,
+            'always',
+            [
+                'build',
+                'chore',
+                'ci',
+                'docs',
+                'feat',
+                'fix',
+                'perf',
+                'refactor',
+                'revert',
+                'style',
+                'test',
+            ],
+        ],
+    },
+    ignores: [
+        (message) => message.includes("Merge pull request #"), // PR merges are allowed
+    ],
+};

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,28 @@
+name: Lint Commit Messages
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v4
+      - name: Install dependencies
+        run: npm install commitlint @commitlint/config-conventional
+      - name: Run commitlint against commits in PR
+        run: |
+          npx commitlint \
+            -g ${{ github.workspace }}/.commitlint.config.mjs \
+            --from ${{ github.event.pull_request.base.sha }} \
+            --to ${{ github.event.pull_request.head.sha }} \
+            --help-url="https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_BASE_REF}/CONTRIBUTING.md" \
+            --verbose


### PR DESCRIPTION
## Description of changes:
This lints incoming commits in PRs to conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). The commit style already follows conventional commits, but this will codify it as required to merge changes.

Conventional commits make it easier to automate the process of generating changelogs and cutting releases. Ideally this change will enable us to use a release automation tool like [release-plz](https://github.com/MarcoIeni/release-plz) to publish SDK crates.

## Limitations
This doesn't yet enforce conventional style on PR titles. This would be a useful place to add conventional commit-style messages to be included in a changelog if multiple underlying commits are used to contribute something that should only have one notable changelog entry.

## Testing:
* [Sample success run](https://github.com/cbgbt/bottlerocket-settings-sdk/actions/runs/10591163016/job/29348140794)
* [Sample failed run](https://github.com/bottlerocket-os/bottlerocket-settings-sdk/actions/runs/10591121034/job/29348024102)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
