### PR TITLE
Add missing NVIDIA_DEVICE_PLUGIN_FEATURE_ENABLED

### DIFF
--- a/bottlerocket-settings-models/settings-extensions/kubernetes/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/kubernetes/src/lib.rs
@@ -21,6 +21,11 @@ use std::net::IpAddr;
 
 mod de;
 
+#[cfg(feature = "nvidia-device-plugin")]
+pub const NVIDIA_DEVICE_PLUGIN_FEATURE_ENABLED: bool = true;
+#[cfg(not(feature = "nvidia-device-plugin"))]
+pub const NVIDIA_DEVICE_PLUGIN_FEATURE_ENABLED: bool = false;
+
 // Kubernetes static pod manifest settings
 #[model]
 pub struct StaticPod {


### PR DESCRIPTION
*Issue #, if available:*
N / A

*Description of changes:*
A change to include the NVIDIA Settings API for kubernetes was merged, but this constant is needed by downstreams to prevent accidental builds of the API.

*Testing*:
I used my own Settings SDK, and confirmed that I had access to the constant

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
