### PR TITLE
feat: drop nvidia-device-plugin feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "bottlerocket-settings-models/settings-extensions/host-containers",
     "bottlerocket-settings-models/settings-extensions/kernel",
     "bottlerocket-settings-models/settings-extensions/kubernetes",
+    "bottlerocket-settings-models/settings-extensions/kubelet-device-plugins",
     "bottlerocket-settings-models/settings-extensions/metrics",
     "bottlerocket-settings-models/settings-extensions/motd",
     "bottlerocket-settings-models/settings-extensions/network",
@@ -74,6 +75,7 @@ settings-extension-ecs = { path = "./bottlerocket-settings-models/settings-exten
 settings-extension-host-containers = { path = "./bottlerocket-settings-models/settings-extensions/host-containers", version = "0.1" }
 settings-extension-kernel = { path = "./bottlerocket-settings-models/settings-extensions/kernel", version = "0.1" }
 settings-extension-kubernetes = { path = "./bottlerocket-settings-models/settings-extensions/kubernetes", version = "0.1" }
+settings-extension-kubelet-device-plugins = { path = "./bottlerocket-settings-models/settings-extensions/kubelet-device-plugins", version = "0.1" }
 settings-extension-metrics = { path = "./bottlerocket-settings-models/settings-extensions/metrics", version = "0.1" }
 settings-extension-motd = { path = "./bottlerocket-settings-models/settings-extensions/motd", version = "0.1" }
 settings-extension-network = { path = "./bottlerocket-settings-models/settings-extensions/network", version = "0.1" }

--- a/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
+++ b/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
@@ -1445,11 +1445,6 @@ mod test_hostname_override_source {
 }
 
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
-// Define the DevicePlugin struct
-#[model(impl_default = true)]
-pub struct K8sDevicePluginsSettings {
-    nvidia: NvidiaDevicePluginSettings,
-}
 
 /// NvidiaRuntimeSettings contains the container runtime settings for Nvidia gpu.
 #[model(impl_default = true)]
@@ -1476,26 +1471,6 @@ pub enum NvidiaDeviceListStrategy {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_serde_k8s_device_plugins() {
-        let test_json = r#"{"nvidia":{"pass-device-specs":true,"device-id-strategy":"index","device-list-strategy":"volume-mounts"}}"#;
-
-        let device_plugins: K8sDevicePluginsSettings = serde_json::from_str(test_json).unwrap();
-        assert_eq!(
-            device_plugins,
-            K8sDevicePluginsSettings {
-                nvidia: Some(NvidiaDevicePluginSettings {
-                    pass_device_specs: Some(true),
-                    device_id_strategy: Some(NvidiaDeviceIdStrategy::Index),
-                    device_list_strategy: Some(NvidiaDeviceListStrategy::VolumeMounts),
-                }),
-            }
-        );
-
-        let results = serde_json::to_string(&device_plugins).unwrap();
-        assert_eq!(results, test_json);
-    }
 
     #[test]
     fn test_serde_nvidia_device_plugins() {

--- a/bottlerocket-settings-models/settings-extensions/kubelet-device-plugins/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/kubelet-device-plugins/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
-name = "settings-extension-kubernetes"
+name = "settings-extension-kubelet-device-plugins"
 version = "0.1.0"
-authors = ["Sean P. Kelly <seankell@amazon.com>"]
+authors = ["Arnaldo Garcia Rincon <agarrcia@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"
 publish = false
-
-[features]
 
 [dependencies]
 bottlerocket-modeled-types.workspace = true
@@ -15,10 +13,6 @@ bottlerocket-settings-sdk.workspace = true
 env_logger.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-toml.workspace = true
 
 [lints]
 workspace = true
-
-[dev-dependencies]
-settings-extension-kubernetes = { workspace = true }

--- a/bottlerocket-settings-models/settings-extensions/kubelet-device-plugins/kubelet-device-plugins.toml
+++ b/bottlerocket-settings-models/settings-extensions/kubelet-device-plugins/kubelet-device-plugins.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]

--- a/bottlerocket-settings-models/settings-extensions/kubelet-device-plugins/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/kubelet-device-plugins/src/lib.rs
@@ -1,0 +1,75 @@
+//! Settings related to Kubelet Device Plugins
+use bottlerocket_model_derive::model;
+use bottlerocket_modeled_types::NvidiaDevicePluginSettings;
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use std::convert::Infallible;
+
+#[model(impl_default = true)]
+pub struct KubeletDevicePluginsV1 {
+    nvidia: NvidiaDevicePluginSettings,
+}
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for KubeletDevicePluginsV1 {
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // Set anything that can be parsed as ECSSettingsV1.
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(
+            existing_partial.unwrap_or_default(),
+        ))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        // KubeletDevicePluginsV1 is validated during deserialization.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bottlerocket_modeled_types::{NvidiaDeviceIdStrategy, NvidiaDeviceListStrategy};
+
+    #[test]
+    fn test_generate_kubelet_device_plugins() {
+        let generated = KubeletDevicePluginsV1::generate(None, None).unwrap();
+        assert_eq!(
+            generated,
+            GenerateResult::Complete(KubeletDevicePluginsV1 { nvidia: None })
+        );
+    }
+
+    #[test]
+    fn test_serde_kubelet_device_plugins() {
+        let test_json = r#"{"nvidia":{"pass-device-specs":true,"device-id-strategy":"index","device-list-strategy":"volume-mounts"}}"#;
+
+        let device_plugins: KubeletDevicePluginsV1 = serde_json::from_str(test_json).unwrap();
+        assert_eq!(
+            device_plugins,
+            KubeletDevicePluginsV1 {
+                nvidia: Some(NvidiaDevicePluginSettings {
+                    pass_device_specs: Some(true),
+                    device_id_strategy: Some(NvidiaDeviceIdStrategy::Index),
+                    device_list_strategy: Some(NvidiaDeviceListStrategy::VolumeMounts),
+                }),
+            }
+        );
+
+        let results = serde_json::to_string(&device_plugins).unwrap();
+        assert_eq!(results, test_json);
+    }
+}

--- a/bottlerocket-settings-models/settings-extensions/kubelet-device-plugins/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/kubelet-device-plugins/src/main.rs
@@ -1,0 +1,18 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_kubelet_device_plugins::KubeletDevicePluginsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("kubelet-device-plugin")
+        .with_models(vec![BottlerocketSetting::<KubeletDevicePluginsV1>::model()])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{}", e);
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/bottlerocket-settings-models/settings-extensions/kubernetes/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/kubernetes/src/lib.rs
@@ -1,7 +1,5 @@
 //! Modeled types for creating Kubernetes settings.
 use bottlerocket_model_derive::model;
-#[cfg(feature = "nvidia-device-plugin")]
-use bottlerocket_modeled_types::K8sDevicePluginsSettings;
 use bottlerocket_modeled_types::{
     CpuManagerPolicy, CredentialProvider, DNSDomain, Identifier, IntegerPercent, KernelCpuSetValue,
     KubernetesAuthenticationMode, KubernetesBootstrapToken, KubernetesCPUManagerPolicyOption,
@@ -96,8 +94,6 @@ pub struct KubernetesSettingsV1 {
     hostname_override_source: KubernetesHostnameOverrideSource,
     // Generated in `k8s-1.25+` variants only
     seccomp_default: bool,
-    #[cfg(feature = "nvidia-device-plugin")]
-    device_plugins: K8sDevicePluginsSettings,
 }
 
 type Result<T> = std::result::Result<T, Infallible>;
@@ -195,8 +191,6 @@ mod test {
                 hostname_override: None,
                 hostname_override_source: None,
                 seccomp_default: None,
-                #[cfg(feature = "nvidia-device-plugin")]
-                device_plugins: None,
             })
         );
     }

--- a/bottlerocket-settings-models/settings-models/Cargo.toml
+++ b/bottlerocket-settings-models/settings-models/Cargo.toml
@@ -9,9 +9,6 @@ publish = false
 exclude = ["README.md"]
 
 [features]
-# With the 'nvidia-device-plugin' feature enabled, the compilation
-# includes NVIDIA GPU-related code, for instance, NvidiaDevicePluginSettings.
-nvidia-device-plugin = ["settings-extension-kubernetes/nvidia-device-plugin"]
 
 [dependencies]
 libc.workspace = true
@@ -37,6 +34,7 @@ settings-extension-ecs.workspace = true
 settings-extension-host-containers.workspace = true
 settings-extension-kernel.workspace = true
 settings-extension-kubernetes.workspace = true
+settings-extension-kubelet-device-plugins.workspace = true
 settings-extension-metrics.workspace = true
 settings-extension-motd.workspace = true
 settings-extension-network.workspace = true

--- a/bottlerocket-settings-models/settings-models/src/lib.rs
+++ b/bottlerocket-settings-models/settings-models/src/lib.rs
@@ -36,6 +36,7 @@ pub use settings_extension_dns::{self, DnsSettingsV1};
 pub use settings_extension_ecs::{self, ECSSettingsV1};
 pub use settings_extension_host_containers::{self, HostContainersSettingsV1};
 pub use settings_extension_kernel::{self, KernelSettingsV1};
+pub use settings_extension_kubelet_device_plugins::{self, KubeletDevicePluginsV1};
 pub use settings_extension_kubernetes::{self, KubernetesSettingsV1};
 pub use settings_extension_metrics::{self, MetricsSettingsV1};
 pub use settings_extension_motd::{self, MotdV1};


### PR DESCRIPTION
*Issue #, if available:*
N / A

*Description of changes:*

Use a setings extension instead of a cargo feature for the kubelet device plugins API. See https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/57#issuecomment-2322174109 for details.

*Testing:*

As part of https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/132 and https://github.com/bottlerocket-os/bottlerocket/pull/4182

1. Instance joined the cluster:

```
NAME                                           STATUS   ROLES    AGE    VERSION
ip-XXXX.us-west-2.compute.internal   Ready    <none>   22s    v1.30.1-eks-e564799
```

2. Files were generated using the new values

```
bash-5.1# apiclient get settings.kubelet-device-plugin
{
  "settings": {
    "kubelet-device-plugin": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "pass-device-specs": true
      }
    }
  }
}

bash-5.1# cat /etc/systemd/system/nvidia-k8s-device-plugin.service.d/exec-start.conf
[Service]
ExecStart=
ExecStart=/usr/bin/nvidia-device-plugin --config-file=/etc/nvidia-k8s-device-plugin/settings.yaml
bash-5.1# cat /etc/nvidia-container-runtime/config.toml
### generated from the template file ###
accept-nvidia-visible-devices-as-volume-mounts = true
accept-nvidia-visible-devices-envvar-when-unprivileged = false

[nvidia-container-cli]
root = "/"
path = "/usr/bin/nvidia-container-cli"
environment = []
ldconfig = "@/sbin/ldconfig"
bash-5.1#
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
