### PR TITLE
fix: align kubernetes cluster name validation with EKS

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,25 @@ allow = [
 exceptions = [
     { name = "generational-arena", allow = ["MPL-2.0"] },
     { name = "unicode-ident", allow = ["MIT", "Apache-2.0", "Unicode-DFS-2016"] },
+    { name = "icu_collections", allow = ["Unicode-3.0"] },
+    { name = "icu_locid", allow = ["Unicode-3.0"] },
+    { name = "icu_locid_transform", allow = ["Unicode-3.0"] },
+    { name = "icu_locid_transform_data", allow = ["Unicode-3.0"] },
+    { name = "icu_normalizer", allow = ["Unicode-3.0"] },
+    { name = "icu_normalizer_data", allow = ["Unicode-3.0"] },
+    { name = "icu_properties", allow = ["Unicode-3.0"] },
+    { name = "icu_properties_data", allow = ["Unicode-3.0"] },
+    { name = "icu_provider", allow = ["Unicode-3.0"] },
+    { name = "icu_provider_macros", allow = ["Unicode-3.0"] },
+    { name = "litemap", allow = ["Unicode-3.0"] },
+    { name = "tinystr", allow = ["Unicode-3.0"] },
+    { name = "writeable", allow = ["Unicode-3.0"] },
+    { name = "yoke", allow = ["Unicode-3.0"] },
+    { name = "yoke-derive", allow = ["Unicode-3.0"] },
+    { name = "zerofrom", allow = ["Unicode-3.0"] },
+    { name = "zerofrom-derive", allow = ["Unicode-3.0"] },
+    { name = "zerovec", allow = ["Unicode-3.0"] },
+    { name = "zerovec-derive", allow = ["Unicode-3.0"] },
 ]
 
 [bans]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This updates the `KubernetesClusterName` validation to align with EKS, per the `eks:CreateCluster` docs: https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateCluster.html#API_CreateCluster_RequestSyntax

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
