### PR TITLE
ci: use intermediate env vars for commitlint job

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -19,10 +19,14 @@ jobs:
       - name: Install dependencies
         run: npm install commitlint @commitlint/config-conventional
       - name: Run commitlint against commits in PR
+        env:
+          WORKSPACE: ${{ github.workspace }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           npx commitlint \
-            -g ${{ github.workspace }}/.commitlint.config.mjs \
-            --from ${{ github.event.pull_request.base.sha }} \
-            --to ${{ github.event.pull_request.head.sha }} \
+            -g "${WORKSPACE}/.commitlint.config.mjs" \
+            --from "${BASE_SHA}" \
+            --to "${HEAD_SHA}" \
             --help-url="https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_BASE_REF}/CONTRIBUTING.md" \
             --verbose


### PR DESCRIPTION
*Issue #, if available:*

Closes #66 

*Description of changes:*

The current commitlint workflow (specifically[ this step](https://github.com/bottlerocket-os/bottlerocket-settings-sdk/blob/bffadea7c58348ede2660d4fa73e2af7e9f6d0ff/.github/workflows/commitlint.yml#L22)) takes raw user-controlled input.

This PR updates the impacted step to use intermediate environment variables for the user-controlled input, follow [this best practice](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).

*Testing*

[Sample run
](https://github.com/bottlerocket-os/bottlerocket-settings-sdk/actions/runs/12005516245/job/33462260956?pr=67)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
