### PR TITLE
Fix errors with rust v1.83

### DIFF
--- a/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
+++ b/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
@@ -669,7 +669,7 @@ mod test_reserved_resources_key {
     }
 }
 
-/// // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
 /// KubernetesQuantityValue represents a string that contains a valid kubernetes quantity value.
 /// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

--- a/bottlerocket-settings-models/scalar-derive/src/lib.rs
+++ b/bottlerocket-settings-models/scalar-derive/src/lib.rs
@@ -539,7 +539,7 @@ fn find_inner_field(data_struct: DataStruct, field_name: Option<&str>) -> (Strin
         }
         Fields::Unnamed(unnamed_field) => {
             let field_name = field_name.unwrap_or("0");
-            return (
+            (
                 field_name.to_string(),
                 typename(
                     &unnamed_field
@@ -551,7 +551,7 @@ fn find_inner_field(data_struct: DataStruct, field_name: Option<&str>) -> (Strin
                         )
                         .ty,
                 ),
-            );
+            )
         }
         Fields::Unit => {
             panic!(

--- a/bottlerocket-settings-plugin/src/settings.rs
+++ b/bottlerocket-settings-plugin/src/settings.rs
@@ -3,12 +3,14 @@ This crate defines the FFI specification for Bottlerocket settings plugins, as w
 functions.
 */
 
-// Avoid empty doc comment warning that originates from the StableAbi derive macro.
-#![allow(clippy::empty_docs)]
 // Avoid false positive improper ctypes warnings for abi_stable's PhantomData markers. We rely on
 // the StableAbi trait to catch any real problems.
-#![allow(improper_ctypes_definitions)]
-
+#![expect(improper_ctypes_definitions)]
+// Avoid warning thrown by StableAbi's definition of non-local `impl`
+#![expect(non_local_definitions)]
+// Avoid `elide the lifetimes` warnings by clippy. The suggested changes do not make the code more
+// readable
+#![expect(clippy::needless_lifetimes)]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as JsonValue;
 use std::path::PathBuf;

--- a/deny.toml
+++ b/deny.toml
@@ -20,7 +20,7 @@ allow = [
 
 exceptions = [
     { name = "generational-arena", allow = ["MPL-2.0"] },
-    { name = "unicode-ident", allow = ["MIT", "Apache-2.0", "Unicode-DFS-2016"] },
+    { name = "unicode-ident", allow = ["MIT", "Apache-2.0", "Unicode-3.0"] },
     { name = "icu_collections", allow = ["Unicode-3.0"] },
     { name = "icu_locid", allow = ["Unicode-3.0"] },
     { name = "icu_locid_transform", allow = ["Unicode-3.0"] },


### PR DESCRIPTION
*Description of changes:*
* Silence newly added linter errors and warnings
* Minor code changes based on linter warnings
* Update licenses to for `unicode-ident` crate

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
