### PR TITLE
feat: Add kubernetes device ownership

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ bottlerocket-template-helper = { path = "./bottlerocket-template-helper", versio
 
 # Settings Models
 bottlerocket-model-derive = { path = "./bottlerocket-settings-models/model-derive", version = "0.1" }
-bottlerocket-modeled-types = { path = "./bottlerocket-settings-models/modeled-types", version = "0.6" }
+bottlerocket-modeled-types = { path = "./bottlerocket-settings-models/modeled-types", version = "0.7" }
 bottlerocket-scalar = { path = "./bottlerocket-settings-models/scalar", version = "0.1" }
 bottlerocket-scalar-derive = { path = "./bottlerocket-settings-models/scalar-derive", version = "0.1" }
 bottlerocket-string-impls-for = { path = "./bottlerocket-settings-models/string-impls-for", version = "0.1" }
@@ -74,7 +74,7 @@ settings-extension-dns = { path = "./bottlerocket-settings-models/settings-exten
 settings-extension-ecs = { path = "./bottlerocket-settings-models/settings-extensions/ecs", version = "0.1" }
 settings-extension-host-containers = { path = "./bottlerocket-settings-models/settings-extensions/host-containers", version = "0.1" }
 settings-extension-kernel = { path = "./bottlerocket-settings-models/settings-extensions/kernel", version = "0.1" }
-settings-extension-kubernetes = { path = "./bottlerocket-settings-models/settings-extensions/kubernetes", version = "0.1" }
+settings-extension-kubernetes = { path = "./bottlerocket-settings-models/settings-extensions/kubernetes", version = "0.2" }
 settings-extension-kubelet-device-plugins = { path = "./bottlerocket-settings-models/settings-extensions/kubelet-device-plugins", version = "0.1" }
 settings-extension-metrics = { path = "./bottlerocket-settings-models/settings-extensions/metrics", version = "0.1" }
 settings-extension-motd = { path = "./bottlerocket-settings-models/settings-extensions/motd", version = "0.1" }

--- a/bottlerocket-settings-models/CHANGELOG.md
+++ b/bottlerocket-settings-models/CHANGELOG.md
@@ -9,7 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - See [unreleased changes here]
 
-[unreleased changes here]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/compare/bottlerocket-settings-models-v0.6.0...HEAD
+[unreleased changes here]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/compare/bottlerocket-settings-models-v0.7.0...HEAD
+
+## [0.7.0] - 2024-12-24
+
+## Model Changes
+
+### Added
+
+- Add kubernetes device ownership settings ([#69])
+
+### Changed
+
+- Align kubernetes cluster name validation with EKS ([#64]) Thanks @cartermckinnon
+
+[#64]:https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/64
+[#69]:https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/69
+
 
 ## [0.6.0] - 2024-10-02
 

--- a/bottlerocket-settings-models/modeled-types/Cargo.toml
+++ b/bottlerocket-settings-models/modeled-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bottlerocket-modeled-types"
-version = "0.6.0"
+version = "0.7.0"
 authors = []
 license = "Apache-2.0 OR MIT"
 edition = "2021"

--- a/bottlerocket-settings-models/settings-extensions/kubernetes/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/kubernetes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "settings-extension-kubernetes"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Sean P. Kelly <seankell@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"

--- a/bottlerocket-settings-models/settings-extensions/kubernetes/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/kubernetes/src/lib.rs
@@ -94,6 +94,7 @@ pub struct KubernetesSettingsV1 {
     hostname_override_source: KubernetesHostnameOverrideSource,
     // Generated in `k8s-1.25+` variants only
     seccomp_default: bool,
+    device_ownership_from_security_context: bool,
 }
 
 type Result<T> = std::result::Result<T, Infallible>;
@@ -191,6 +192,7 @@ mod test {
                 hostname_override: None,
                 hostname_override_source: None,
                 seccomp_default: None,
+                device_ownership_from_security_context: None,
             })
         );
     }

--- a/bottlerocket-settings-models/settings-models/Cargo.toml
+++ b/bottlerocket-settings-models/settings-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bottlerocket-settings-models"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"


### PR DESCRIPTION
*Description of changes:*

* Create a new setting to hold the `device-ownership-from-security-context` boolean. This is to support the same setting in the containerd CRI plugin as described [here](https://kubernetes.io/blog/2021/11/09/non-root-containers-and-devices/)

Testing done:

* The setting shows up as expected in an AMI built using this `settings-sdk`
  ```
  # apiclient get settings.kubernetes.device-ownership-from-security-context
  {
    "settings": {
      "kubernetes": {
        "device-ownership-from-security-context": false
      }
    }
  }
  ```

* Changing the setting works as defined:
  ```
  [root@admin]# apiclient set settings.kubernetes.device-ownership-from-security-context="true"
  [root@admin]# apiclient get settings.kubernetes.device-ownership-from-security-context
  {
    "settings": {
      "kubernetes": {
        "device-ownership-from-security-context": true
      }
    }
  }
  [root@admin]# sheltie cat /etc/containerd/config.toml | grep device
  device_ownership_from_security_context = true
  ```

* The setting has the desired effect on device ownership
    * When `true`:
      ``` 
      # kubectl exec -it single-node-test -- bash
      ubuntu@single-node-test:/$ ls -lah /dev/ | grep neuron
      crw-------. 1 ubuntu 2000 244, 0 Dec 20 00:25 neuron0
      ```
    * When `false`:
      ``` 
      # kubectl exec -it single-node-test -- bash
      ubuntu@single-node-test:/$ ls -lah /dev/ | grep neuron
      crw-------. 1 root root 244, 0 Dec 19 20:03 neuron0
      ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
