### PR TITLE
defaults-helper: rerun on changes to any file in defaults.d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ members = [
 bottlerocket-settings-plugin = { path = "./bottlerocket-settings-plugin", version = "0.1" }
 bottlerocket-settings-derive = { path = "./bottlerocket-settings-derive", version = "0.1" }
 bottlerocket-settings-sdk = { path = "./bottlerocket-settings-sdk", version = "0.1" }
-bottlerocket-defaults-helper = { path = "./bottlerocket-defaults-helper", version = "0.1" }
+bottlerocket-defaults-helper = { path = "./bottlerocket-defaults-helper", version = "0.1.1" }
 bottlerocket-template-helper = { path = "./bottlerocket-template-helper", version = "0.1" }
 
 # Settings Models

--- a/bottlerocket-defaults-helper/Cargo.toml
+++ b/bottlerocket-defaults-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bottlerocket-defaults-helper"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"

--- a/bottlerocket-defaults-helper/src/lib.rs
+++ b/bottlerocket-defaults-helper/src/lib.rs
@@ -25,6 +25,9 @@ pub fn generate_defaults_toml() -> Result<()> {
     })?);
     defaults_dir.push("defaults.d");
 
+    // Reflect that we need to rerun if any of the default settings files have changed.
+    println!("cargo::rerun-if-changed={}", defaults_dir.display());
+
     // Find TOML config files specified by the variant.
     let walker = WalkDir::new(&defaults_dir)
         .follow_links(true) // we expect users to link to shared files
@@ -38,9 +41,6 @@ pub fn generate_defaults_toml() -> Result<()> {
     let mut defaults = Value::Table(Map::new());
     for entry in walker {
         let entry = entry.context(error::ListFilesSnafu { dir: &defaults_dir })?;
-
-        // Reflect that we need to rerun if any of the default settings files have changed.
-        println!("cargo:rerun-if-changed={}", entry.path().display());
 
         let data = fs::read_to_string(entry.path()).context(error::FileSnafu {
             op: "read",


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/bottlerocket-os/twoliter/issues/422

*Description of changes:*
Per https://github.com/bottlerocket-os/twoliter/issues/422, adding a symlink to a `defaults.d` directory does not result in a rebuild of defaults generated by `bottlerocket-defaults-helper`.

This is because we were emitting `cargo::rerun-if-changed` directives for each file discovered in the defaults directory, but not scanning the directory itself for new files.

This changes `bottlerocket-defautls-helper` to emit a single `rerun-if-changed` directive for the entire `defaults.d` directory, which will result in [cargo scanning the directory for changes](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed) when detecting rebuilds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
