### PR TITLE
Support for singleProcessOOMKill through Kubernetes API

### DIFF
--- a/bottlerocket-settings-models/settings-extensions/kubernetes/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/kubernetes/src/lib.rs
@@ -97,6 +97,8 @@ pub struct KubernetesSettingsV1 {
     // Generated in `k8s-1.25+` variants only
     seccomp_default: bool,
     device_ownership_from_security_context: bool,
+    // Generated in `k8s-1.32+` variants only
+    single_process_oom_kill: bool,
 }
 
 type Result<T> = std::result::Result<T, Infallible>;
@@ -197,6 +199,7 @@ mod test {
                 hostname_override_source: None,
                 seccomp_default: None,
                 device_ownership_from_security_context: None,
+                single_process_oom_kill: None,
             })
         );
     }


### PR DESCRIPTION
*Description of changes:*

This adds support for the `singleProcessOOMKill` [[1]] flag used by the kubelet starting with version 1.32.

[1]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md

*Testing*

In combination with local changes to be pushed to the Core Kit and BoB, I confirmed that I can set the setting:

```bash
[root@admin]# apiclient get settings.kubernetes.single
{
  "settings": {
    "kubernetes": {
      "single-process-oom-kill": true
    }
  }
}
```

Confirmed that the setting was rendered:

```
staticPodPath: "/etc/kubernetes/static-pods/"
failSwapOn: false
singleProcessOOMKill: true
```

Confirmed that the cgroup for the pod was configured:

```
# Without the setting, this returns nothing
bash-5.1# find /sys -name "*memory.oom*" -exec cat {} \; | grep 1
1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
