### PR TITLE
chore: extend pr template with note on karpenter k8s settings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+*Issue #, if available:*
+
+*Description of changes:*
+
+*Does this change affect `settings.kubernetes`?*
+- [ ] Yes, and I opened a PR to github.com/aws/karpenter-provider-aws to add the setting to Karpenter:
+- [x] No
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
*Description of changes:*

Add a note in PR template about extending Karpenter's settings model whenever Bottlerocket adds new settings under`settings.kubernetes`. Karpenter models Bottlerocket Kubernetes settings in their project [here](https://github.com/aws/karpenter-provider-aws/blob/main/pkg/providers/amifamily/bootstrap/bottlerocketsettings.go) and any new setting is added to `settings.kubernetes` must also be added to the Karpenter model in order for users to be able to configure the setting via Karpenter userData. 

This PR template is the same as the bottlerocket-os org's template (https://github.com/bottlerocket-os/.github/blob/master/PULL_REQUEST_TEMPLATE) with checklist added to prompt PR authors to open a PR to github.com/aws/karpenter-provider-aws per-emptively with the setting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
