### PR TITLE
feat: k8s: add `memory-swap-behavior` setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ bottlerocket-template-helper = { path = "./bottlerocket-template-helper", versio
 
 # Settings Models
 bottlerocket-model-derive = { path = "./bottlerocket-settings-models/model-derive", version = "0.1" }
-bottlerocket-modeled-types = { path = "./bottlerocket-settings-models/modeled-types", version = "0.9" }
+bottlerocket-modeled-types = { path = "./bottlerocket-settings-models/modeled-types", version = "0.10" }
 bottlerocket-scalar = { path = "./bottlerocket-settings-models/scalar", version = "0.1" }
 bottlerocket-scalar-derive = { path = "./bottlerocket-settings-models/scalar-derive", version = "0.1" }
 bottlerocket-string-impls-for = { path = "./bottlerocket-settings-models/string-impls-for", version = "0.1" }
@@ -74,7 +74,7 @@ settings-extension-dns = { path = "./bottlerocket-settings-models/settings-exten
 settings-extension-ecs = { path = "./bottlerocket-settings-models/settings-extensions/ecs", version = "0.1" }
 settings-extension-host-containers = { path = "./bottlerocket-settings-models/settings-extensions/host-containers", version = "0.1" }
 settings-extension-kernel = { path = "./bottlerocket-settings-models/settings-extensions/kernel", version = "0.1" }
-settings-extension-kubernetes = { path = "./bottlerocket-settings-models/settings-extensions/kubernetes", version = "0.3" }
+settings-extension-kubernetes = { path = "./bottlerocket-settings-models/settings-extensions/kubernetes", version = "0.4" }
 settings-extension-kubelet-device-plugins = { path = "./bottlerocket-settings-models/settings-extensions/kubelet-device-plugins", version = "0.3" }
 settings-extension-metrics = { path = "./bottlerocket-settings-models/settings-extensions/metrics", version = "0.1" }
 settings-extension-motd = { path = "./bottlerocket-settings-models/settings-extensions/motd", version = "0.1" }

--- a/bottlerocket-settings-models/modeled-types/Cargo.toml
+++ b/bottlerocket-settings-models/modeled-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bottlerocket-modeled-types"
-version = "0.9.0"
+version = "0.10.0"
 authors = []
 license = "Apache-2.0 OR MIT"
 edition = "2021"

--- a/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
+++ b/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
@@ -1459,6 +1459,35 @@ mod test_hostname_override_source {
     }
 }
 
+/// KubernetesMemorySwapBehavior represents the valid options for the memory swap behavior.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Scalar)]
+pub enum KubernetesMemorySwapBehavior {
+    #[serde(alias = "no-swap")]
+    NoSwap,
+    #[serde(alias = "limited-swap")]
+    LimitedSwap,
+}
+
+#[cfg(test)]
+mod test_kubernetes_memory_swap_behavior {
+    use super::KubernetesMemorySwapBehavior;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn good_swap_behavior() {
+        for ok in &["NoSwap", "no-swap", "LimitedSwap", "limited-swap"] {
+            KubernetesMemorySwapBehavior::try_from(*ok).unwrap();
+        }
+    }
+
+    #[test]
+    fn bad_swap_behavior() {
+        for err in &["", "bad", "100", &"a".repeat(64)] {
+            KubernetesMemorySwapBehavior::try_from(*err).unwrap_err();
+        }
+    }
+}
+
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
 /// NvidiaDevicePluginSettings contains the device sharing and partitioning related settings for Nvidia gpu.

--- a/bottlerocket-settings-models/modeled-types/src/lib.rs
+++ b/bottlerocket-settings-models/modeled-types/src/lib.rs
@@ -156,6 +156,9 @@ pub mod error {
 
         #[snafu(display("Invalid Kernel CpuSet value '{}'", input))]
         InvalidKernelCpuSetValue { input: String },
+
+        #[snafu(display("Invalid memory swap behavior value '{}'", input))]
+        InvalidMemorySwapBehavior { input: String },
     }
 
     /// Creates a `ValidationError` with a consistent message for strings with regex validations

--- a/bottlerocket-settings-models/settings-extensions/kubernetes/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/kubernetes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "settings-extension-kubernetes"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Sean P. Kelly <seankell@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"

--- a/bottlerocket-settings-models/settings-extensions/kubernetes/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/kubernetes/src/lib.rs
@@ -6,9 +6,10 @@ use bottlerocket_modeled_types::{
     KubernetesCloudProvider, KubernetesClusterDnsIp, KubernetesClusterName,
     KubernetesDurationValue, KubernetesEvictionKey, KubernetesHostnameOverrideSource,
     KubernetesLabelKey, KubernetesLabelValue, KubernetesMemoryManagerPolicy,
-    KubernetesMemoryReservation, KubernetesQuantityValue, KubernetesReservedResourceKey,
-    KubernetesTaintValue, KubernetesThresholdValue, NonNegativeInteger, SingleLineString,
-    TopologyManagerPolicy, TopologyManagerScope, Url, ValidBase64, ValidLinuxHostname,
+    KubernetesMemoryReservation, KubernetesMemorySwapBehavior, KubernetesQuantityValue,
+    KubernetesReservedResourceKey, KubernetesTaintValue, KubernetesThresholdValue,
+    NonNegativeInteger, SingleLineString, TopologyManagerPolicy, TopologyManagerScope, Url,
+    ValidBase64, ValidLinuxHostname,
 };
 use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
 
@@ -83,6 +84,7 @@ pub struct KubernetesSettingsV1 {
     memory_manager_reserved_memory: HashMap<Identifier, KubernetesMemoryReservation>,
     memory_manager_policy: KubernetesMemoryManagerPolicy,
     reserved_cpus: KernelCpuSetValue,
+    memory_swap_behavior: KubernetesMemorySwapBehavior,
 
     // Settings where we generate a value based on the runtime environment.  The user can specify a
     // value to override the generated one, but typically would not.
@@ -190,6 +192,7 @@ mod test {
                 memory_manager_reserved_memory: None,
                 memory_manager_policy: None,
                 reserved_cpus: None,
+                memory_swap_behavior: None,
                 max_pods: None,
                 cluster_dns_ip: None,
                 cluster_domain: None,

--- a/bottlerocket-settings-models/settings-models/Cargo.toml
+++ b/bottlerocket-settings-models/settings-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bottlerocket-settings-models"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"


### PR DESCRIPTION
This change adds a new `memory-swap-behavior` setting to control the k8s `memorySwap.swapBehavior` config. `memorySwap.swapBehavior` configures swap memory available to container workloads. By default containers are not allowed to use swap, so making this setting configurable is a requirement for using swap with Bottlerocket.

*Issue:* https://github.com/bottlerocket-os/bottlerocket/issues/4547

*Description of changes:*

This PR extends `KubernetesSettingsV1` with a new `memory-swap-behavior` setting, to control the `memorySwap.swapBehavior` kubelet config.

Testing the new setting with a custom Bottlerocket build is documented in https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/541.

----------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

