### PR TITLE
Fix clippy lints for Rust 1.88

### DIFF
--- a/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
+++ b/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
@@ -774,7 +774,8 @@ mod test_kubernetes_cloud_provider {
 
     #[test]
     fn disallowed_providers() {
-        for err in &["internal"] {
+        {
+            let err = &"internal";
             KubernetesCloudProvider::try_from(*err).unwrap_err();
         }
     }
@@ -1088,15 +1089,14 @@ impl<'de> Deserialize<'de> for IntegerPercent {
             Value::String(s) => (s.clone(), IntegerPercentMode::String),
             _ => {
                 return Err(D::Error::custom(format!(
-                    "Unable to deserialize value, it is not a number or a string: {:?}",
-                    json_value,
+                    "Unable to deserialize value, it is not a number or a string: {json_value:?}",
                 )))
             }
         };
 
         let value = s
             .parse::<i32>()
-            .map_err(|e| D::Error::custom(format!("Unable to parse {} as an integer: {}", s, e)))?;
+            .map_err(|e| D::Error::custom(format!("Unable to parse {s} as an integer: {e}")))?;
 
         // This new function will clamp the range to 0..100 with a nice error message.
         Self::new(value, mode).map_err(|e| D::Error::custom(e.to_string()))
@@ -1345,7 +1345,8 @@ mod test_kubernetes_cpu_manager_policy_option {
 
     #[test]
     fn good_cpu_manager_policy_option() {
-        for ok in &["full-pcpus-only"] {
+        {
+            let ok = &"full-pcpus-only";
             KubernetesCPUManagerPolicyOption::try_from(*ok).unwrap();
         }
     }
@@ -1643,7 +1644,7 @@ mod test_nvidia_device_plugins {
         device_list_strategy: Option<NvidiaDeviceListStrategy>,
     ) -> NvidiaDevicePluginSettings {
         NvidiaDevicePluginSettings {
-            device_list_strategy: device_list_strategy,
+            device_list_strategy,
             ..NvidiaDevicePluginSettings::default()
         }
     }

--- a/bottlerocket-settings-models/modeled-types/src/shared.rs
+++ b/bottlerocket-settings-models/modeled-types/src/shared.rs
@@ -460,7 +460,7 @@ impl TryFrom<&str> for Url {
         } else {
             // It's very common to specify URLs without a scheme, so we add one and see if that
             // fixes parsing.
-            let prefixed = format!("http://{}", input);
+            let prefixed = format!("http://{input}");
             if prefixed.parse::<url::Url>().is_ok() {
                 return Ok(Url {
                     inner: input.to_string(),
@@ -968,8 +968,7 @@ impl<'de> serde::Deserialize<'de> for ApiclientCommand {
         let original: Vec<String> = serde::Deserialize::deserialize(deserializer)?;
         Self::try_from(original).map_err(|e| {
             <D::Error as serde::de::Error>::custom(format!(
-                "Unable to deserialize into ApiclientCommand: {}",
-                e
+                "Unable to deserialize into ApiclientCommand: {e}"
             ))
         })
     }

--- a/bottlerocket-settings-models/scalar-derive/src/lib.rs
+++ b/bottlerocket-settings-models/scalar-derive/src/lib.rs
@@ -533,8 +533,7 @@ fn find_inner_field(data_struct: DataStruct, field_name: Option<&str>) -> (Strin
                 }
             }
             panic!(
-                "The Scalar derive macro could not find a field named '{}', in this struct",
-                field_name
+                "The Scalar derive macro could not find a field named '{field_name}', in this struct",
             );
         }
         Fields::Unnamed(unnamed_field) => {

--- a/bottlerocket-settings-models/scalar-derive/tests/tests.rs
+++ b/bottlerocket-settings-models/scalar-derive/tests/tests.rs
@@ -21,7 +21,7 @@ fn simple_string() {
     let s = SimpleString::new("foo").unwrap();
     // Check that a few dereferencing conveniences compile
     let eq1 = "foo" == s;
-    let eq2 = String::from("foo") == s;
+    let eq2 = "foo" == s;
     let eq3 = "foo" == &s;
     // Assert these in a way that doesn't use assert_eq and doesn't make my IDE mad
     assert!(eq1);
@@ -43,7 +43,7 @@ impl Validate for UnnamedFields {
         let input = input.into();
         // Contrived weirdness
         if input == 0 {
-            return Err(ValidationError::new("never zero"));
+            Err(ValidationError::new("never zero"))
         } else if input == 1 {
             Ok(Self(2, "it was 1 but I changed it to 2".to_string()))
         } else {
@@ -56,7 +56,7 @@ impl Validate for UnnamedFields {
 fn unnamed_fields() {
     let i = UnnamedFields::new(1u16).unwrap();
     let eq1 = 2u16 == i;
-    let eq2 = &2u16 == &i;
+    let eq2 = 2u16 == i;
     assert!(eq1);
     assert!(eq2);
 }
@@ -81,7 +81,7 @@ impl Validate for SecondField {
 fn second_field() {
     let i = SecondField::new(3u16).unwrap();
     let eq1 = 3u16 == i;
-    let eq2 = &3u16 == &i;
+    let eq2 = 3u16 == i;
     assert!(eq1);
     assert!(eq2);
 }

--- a/bottlerocket-settings-models/settings-extensions/autoscaling/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/autoscaling/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/aws/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/aws/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/bootstrap-commands/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/bootstrap-commands/src/lib.rs
@@ -66,6 +66,8 @@ impl SettingsModel for BootstrapCommandsSettingsV1 {
     }
 }
 
+type Result<T> = std::result::Result<T, Infallible>;
+
 #[cfg(test)]
 mod test_bootstrap_command {
     use super::*;
@@ -144,5 +146,3 @@ mod test_bootstrap_command {
         assert!(bootstrap_commands_err.is_err());
     }
 }
-
-type Result<T> = std::result::Result<T, Infallible>;

--- a/bottlerocket-settings-models/settings-extensions/bootstrap-commands/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/bootstrap-commands/src/main.rs
@@ -13,7 +13,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/bootstrap-containers/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/bootstrap-containers/src/main.rs
@@ -13,7 +13,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/cloudformation/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/cloudformation/src/main.rs
@@ -13,7 +13,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/container-registry/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/container-registry/src/lib.rs
@@ -97,11 +97,11 @@ mod test {
 
         assert_eq!(mirrors.len(), 1);
         assert_eq!(
-            mirrors[0].registry.clone().unwrap(),
+            mirrors.first().unwrap().registry.clone().unwrap(),
             SingleLineString::try_from("foo").unwrap(),
         );
         assert_eq!(
-            mirrors[0].endpoint.clone().unwrap(),
+            mirrors.first().unwrap().endpoint.clone().unwrap(),
             vec!(Url::try_from("https://example.net").unwrap()),
         );
     }
@@ -115,15 +115,15 @@ mod test {
 
         assert_eq!(credentials.len(), 1);
         assert_eq!(
-            credentials[0].registry.clone().unwrap(),
+            credentials.first().unwrap().registry.clone().unwrap(),
             SingleLineString::try_from("foo").unwrap(),
         );
         assert_eq!(
-            credentials[0].auth.clone().unwrap(),
+            credentials.first().unwrap().auth.clone().unwrap(),
             ValidBase64::try_from("Ym90dGxlcm9ja2V0").unwrap(),
         );
-        assert!(credentials[0].username.is_none());
-        assert!(credentials[0].password.is_none());
-        assert!(credentials[0].identitytoken.is_none());
+        assert!(credentials.first().unwrap().username.is_none());
+        assert!(credentials.first().unwrap().password.is_none());
+        assert!(credentials.first().unwrap().identitytoken.is_none());
     }
 }

--- a/bottlerocket-settings-models/settings-extensions/container-registry/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/container-registry/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/container-runtime/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/container-runtime/src/main.rs
@@ -13,7 +13,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/dns/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/dns/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/ecs/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/ecs/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/host-containers/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/host-containers/src/main.rs
@@ -13,7 +13,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/kernel/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/kernel/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/kubelet-device-plugins/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/kubelet-device-plugins/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/kubernetes/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/kubernetes/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/metrics/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/metrics/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/motd/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/motd/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/network/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/network/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/ntp/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/ntp/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/nvidia-container-runtime/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/nvidia-container-runtime/src/main.rs
@@ -13,7 +13,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/oci-defaults/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/oci-defaults/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/oci-hooks/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/oci-hooks/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/pki/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/pki/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-models/settings-extensions/updates/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/updates/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> ExitCode {
     {
         Ok(extension) => extension.run(),
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-sdk/src/extension/proto1.rs
+++ b/bottlerocket-settings-sdk/src/extension/proto1.rs
@@ -26,7 +26,7 @@ pub fn run_extension<P: Proto1>(extension: P, cmd: Proto1Command) -> ExitCode {
             ExitCode::SUCCESS
         }
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             ExitCode::FAILURE
         }
     }

--- a/bottlerocket-settings-sdk/src/migrate/linear/mod.rs
+++ b/bottlerocket-settings-sdk/src/migrate/linear/mod.rs
@@ -468,7 +468,7 @@ mod test {
         ]
         .into_iter()
         .for_each(|(start, to, expected)| {
-            eprintln!("Testing migration from {} to {}", start, to);
+            eprintln!("Testing migration from {start} to {to}");
             let migration: Option<Vec<MigrationDirection>> = LinearMigrator
                 .find_migration_route(&models, start, to)
                 .map(|route| route.collect());
@@ -540,7 +540,7 @@ mod test {
         ]
         .into_iter()
         .for_each(|(starting_value, starting_version)| {
-            eprintln!("Testing flood migration starting from {}", starting_version);
+            eprintln!("Testing flood migration starting from {starting_version}");
             let results = LinearMigrator
                 .perform_flood_migrations(&models, starting_value, starting_version)
                 .unwrap();

--- a/bottlerocket-settings-sdk/tests/motd/v1.rs
+++ b/bottlerocket-settings-sdk/tests/motd/v1.rs
@@ -40,7 +40,7 @@ impl SettingsModel for MotdV1 {
     ) -> Result<GenerateResult<Self::PartialKind, Self>> {
         // We generate a default motd if there is none.
         Ok(GenerateResult::Complete(
-            existing_partial.unwrap_or(MotdV1::default()),
+            existing_partial.unwrap_or_default(),
         ))
     }
 

--- a/bottlerocket-settings-sdk/tests/motd/v2.rs
+++ b/bottlerocket-settings-sdk/tests/motd/v2.rs
@@ -90,7 +90,7 @@ fn exclaim(i: String) -> Result<String> {
 
 #[template_helper(ident = question_helper)]
 fn question(one: String, two: String) -> Result<String> {
-    Ok(format!("{}? {}??", one, two))
+    Ok(format!("{one}? {two}??"))
 }
 
 #[test]

--- a/bottlerocket-settings-sdk/tests/sample_extensions.rs
+++ b/bottlerocket-settings-sdk/tests/sample_extensions.rs
@@ -34,7 +34,7 @@ mod helpers {
         Mo: AsTypeErasedModel,
     {
         extension
-            .try_run_with_args(&[
+            .try_run_with_args([
                 "extension",
                 "proto1",
                 "set",
@@ -46,7 +46,6 @@ mod helpers {
             .context("Failed to run settings extension CLI")
             .map(|s| {
                 assert!(s.is_empty());
-                ()
             })
     }
 
@@ -129,7 +128,6 @@ mod helpers {
             .context("Failed to run settings extension CLI")
             .map(|s| {
                 assert!(s.is_empty());
-                ()
             })
     }
 
@@ -207,8 +205,7 @@ mod helpers {
     {
         let template_args: Vec<String> = args
             .into_iter()
-            .map(|arg| vec!["--arg".to_string(), arg.to_string()])
-            .flatten()
+            .flat_map(|arg| vec!["--arg".to_string(), arg.to_string()])
             .collect();
 
         let args = [

--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,11 @@ allow = [
 
 exceptions = [
     { name = "generational-arena", allow = ["MPL-2.0"] },
+    { name = "unicode-ident", version = "1.0.13", allow = [
+        "MIT",
+        "Apache-2.0",
+        "Unicode-DFS-2016",
+    ] },
 ]
 
 [bans]


### PR DESCRIPTION
*Issue #, if available:*

Related: https://github.com/bottlerocket-os/bottlerocket-sdk/issues/284

*Description of changes:*

* Fix clippy lints for Rust 1.88
* Allow Unicode-DFS-2016 license

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
