### PR TITLE
github: skip workflows on forks

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   commitlint:
+    if: github.repository == 'bottlerocket-os/bottlerocket-settings-sdk'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'bottlerocket-os/bottlerocket-settings-sdk'
     runs-on:
       group: bottlerocket
       labels: bottlerocket_ubuntu-latest_8-core


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adds the missing guardrail that prevents workflows from running on forks of this repo. Because we use self-hosted runners, the checks in this repo fail on forks. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
