### PR TITLE
feat: update k8s kube-reserved and system-reserved settings to specify pid 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ bottlerocket-template-helper = { path = "./bottlerocket-template-helper", versio
 
 # Settings Models
 bottlerocket-model-derive = { path = "./bottlerocket-settings-models/model-derive", version = "0.1" }
-bottlerocket-modeled-types = { path = "./bottlerocket-settings-models/modeled-types", version = "0.11" }
+bottlerocket-modeled-types = { path = "./bottlerocket-settings-models/modeled-types", version = "0.12" }
 bottlerocket-scalar = { path = "./bottlerocket-settings-models/scalar", version = "0.1" }
 bottlerocket-scalar-derive = { path = "./bottlerocket-settings-models/scalar-derive", version = "0.1" }
 bottlerocket-string-impls-for = { path = "./bottlerocket-settings-models/string-impls-for", version = "0.1" }

--- a/bottlerocket-settings-models/CHANGELOG.md
+++ b/bottlerocket-settings-models/CHANGELOG.md
@@ -9,7 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - See [unreleased changes here]
 
-[unreleased changes here]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/compare/bottlerocket-settings-models-v0.15.0...HEAD
+[unreleased changes here]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/compare/bottlerocket-settings-models-v0.16.0...HEAD
+
+## [0.16.0] - 2025-09-19
+
+## Model Changes
+
+### Added
+
+- Added `pid` setting to the `kube-reserved` and `system-reserved` kubernetes settings ([#98])
+
+[#98]:https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/98
+
+[0.16.0]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/compare/bottlerocket-settings-models-v0.15.0...bottlerocket-settings-models-v0.16.0
 
 ## [0.15.0] - 2025-09-11
 

--- a/bottlerocket-settings-models/modeled-types/Cargo.toml
+++ b/bottlerocket-settings-models/modeled-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bottlerocket-modeled-types"
-version = "0.11.0"
+version = "0.12.0"
 authors = []
 license = "Apache-2.0 OR MIT"
 edition = "2021"

--- a/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
+++ b/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
@@ -628,6 +628,7 @@ enum ReservedResources {
     Memory,
     #[serde(rename = "ephemeral-storage")]
     EphemeralStorage,
+    Pid,
 }
 
 impl TryFrom<&str> for KubernetesReservedResourceKey {
@@ -656,7 +657,7 @@ mod test_reserved_resources_key {
 
     #[test]
     fn good_reserved_resources_key() {
-        for ok in &["cpu", "memory", "ephemeral-storage"] {
+        for ok in &["cpu", "memory", "ephemeral-storage", "pid"] {
             KubernetesReservedResourceKey::try_from(*ok).unwrap();
         }
     }

--- a/bottlerocket-settings-models/scalar/src/lib.rs
+++ b/bottlerocket-settings-models/scalar/src/lib.rs
@@ -185,7 +185,7 @@ impl Display for ValidationError {
 impl Error for ValidationError {
     /// Return the underlying error if there is one.
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        self.source.as_ref().map(|e| e.as_ref() as &(dyn Error))
+        self.source.as_ref().map(|e| e.as_ref() as &dyn Error)
     }
 }
 

--- a/bottlerocket-settings-models/settings-models/Cargo.toml
+++ b/bottlerocket-settings-models/settings-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bottlerocket-settings-models"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/bottlerocket-os/bottlerocket/issues/3788

*Description of changes:*

Bottlerocket's current [`system-reserved` setting](https://bottlerocket.dev/en/os/1.44.x/api/settings/kubernetes/#system-reserved) and [`kube-reserved` setting](https://bottlerocket.dev/en/os/1.44.x/api/settings/kubernetes/#kube-reserved) only supports `cpu`, `memory`, and `ephemeral-storage` resources.

This PR adds `pid` as another resource that can be specified as described [here](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#system-reserved).

PID limits and reservations was marked as a stable feature in k8s-1.20 ([source](https://kubernetes.io/docs/concepts/policy/pid-limiting/)).

Also, bumping `settings-models` version to 0.16.0 + updating changelog for new release.

*Testing Description:*

1. `cargo test`
2. Built a custom k8s-1.33 variant and created a nodegroup with it and the following userdata:

```
bottlerocket:
      settings:
        kubernetes:
          kube-reserved:
            pid: "9999"
          system-reserved:
            pid: "1000"
```

   - Node joined the cluster
   - Settings persisted
    
```
[ssm-user@control]$ apiclient get settings.kubernetes.kube-reserved
{
  "settings": {
    "kubernetes": {
      "kube-reserved": {
        "pid": "9999"
      }
    }
  }
}
[ssm-user@control]$ apiclient get settings.kubernetes.system-reserved
{
  "settings": {
    "kubernetes": {
      "system-reserved": {
        "pid": "1000"
      }
    }
  }
}
```
- Kubelet config rendered
  
```
bash-5.1# cat /etc/kubernetes/kubelet/config | grep pid
  pid: "9999"
  pid: "1000"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
