### PR TITLE
Improve regex for NvidiaGpuModel

### DIFF
--- a/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
+++ b/bottlerocket-settings-models/modeled-types/src/kubernetes.rs
@@ -1581,7 +1581,7 @@ pub struct NvidiaGpuModel {
 }
 
 lazy_static! {
-    pub(crate) static ref NVIDIAGPU_NAME: Regex = Regex::new(r"^([a-z])(\d+)\.(\d+)gb$").unwrap();
+    pub(crate) static ref NVIDIAGPU_NAME: Regex = Regex::new(r"^([a-z0-9]+).(\d+)gb$").unwrap();
 }
 
 impl TryFrom<&str> for NvidiaGpuModel {
@@ -1652,7 +1652,13 @@ mod test_nvidia_device_plugins {
 
     #[test]
     fn valid_gpu_model() {
-        for ok in &["a100.40gb", "a100.80gb", "h100.80gb", "h100.141gb"] {
+        for ok in &[
+            "a100.40gb",
+            "a100.80gb",
+            "h100.80gb",
+            "h100.141gb",
+            "rtxpro6000.98gb",
+        ] {
             assert!(NvidiaGpuModel::try_from(*ok).is_ok());
         }
     }


### PR DESCRIPTION
*Description of changes:*

Some devices that support MIG have longer names than a single letter plus numbers such as the RTX PRO 6000. This change updates the regex to support these and future devices that have longer names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
