### PR TITLE
feat: add settings model for notation image verifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "bottlerocket-settings-models/settings-extensions/dns",
     "bottlerocket-settings-models/settings-extensions/ecs",
     "bottlerocket-settings-models/settings-extensions/host-containers",
+    "bottlerocket-settings-models/settings-extensions/image-verifier-plugins",
     "bottlerocket-settings-models/settings-extensions/kernel",
     "bottlerocket-settings-models/settings-extensions/kubernetes",
     "bottlerocket-settings-models/settings-extensions/kubelet-device-plugins",
@@ -75,6 +76,7 @@ settings-extension-container-runtime-plugins = { path = "./bottlerocket-settings
 settings-extension-dns = { path = "./bottlerocket-settings-models/settings-extensions/dns", version = "0.1" }
 settings-extension-ecs = { path = "./bottlerocket-settings-models/settings-extensions/ecs", version = "0.1" }
 settings-extension-host-containers = { path = "./bottlerocket-settings-models/settings-extensions/host-containers", version = "0.2" }
+settings-extension-image-verifier-plugins = { path = "./bottlerocket-settings-models/settings-extensions/image-verifier-plugins", version = "0.1" }
 settings-extension-kernel = { path = "./bottlerocket-settings-models/settings-extensions/kernel", version = "0.1" }
 settings-extension-kubernetes = { path = "./bottlerocket-settings-models/settings-extensions/kubernetes", version = "0.6" }
 settings-extension-kubelet-device-plugins = { path = "./bottlerocket-settings-models/settings-extensions/kubelet-device-plugins", version = "0.3" }

--- a/bottlerocket-settings-models/CHANGELOG.md
+++ b/bottlerocket-settings-models/CHANGELOG.md
@@ -20,9 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `image-minimum-gc-age` and `image-maximum-gc-age` kubernetes settings ([#87]) - Thanks @parnniti!
 - Added `ids-per-pod` and `max-parallel-image-pulls` kubernetes settings ([#104])
 - Added beta options for `cpu-manager-policy-options` kubernetes settings ([#104])
+- Added `image-verifier-plugins` settings extension with initial support for notation trustpolicy document ([#106])
 
 [#87]:https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/87
 [#104]:https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/104
+[#106]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/106
 
 [0.17.0]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/compare/bottlerocket-settings-models-v0.16.0...bottlerocket-settings-models-v0.17.0
 

--- a/bottlerocket-settings-models/settings-extensions/image-verifier-plugins/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/image-verifier-plugins/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "settings-extension-image-verifier-plugins"
+version = "0.1.0"
+authors = ["Gavin Inglis <giinglis@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+
+[dependencies]
+bottlerocket-modeled-types.workspace = true
+bottlerocket-model-derive.workspace = true
+bottlerocket-settings-sdk.workspace = true
+env_logger.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/bottlerocket-settings-models/settings-extensions/image-verifier-plugins/image-verifier-plugins.toml
+++ b/bottlerocket-settings-models/settings-extensions/image-verifier-plugins/image-verifier-plugins.toml
@@ -1,0 +1,13 @@
+[extension]
+supported-versions = [
+    "v1"
+]
+default-version = "v1"
+
+[v1]
+[v1.validation.cross-validates]
+
+[v1.templating]
+helpers = []
+
+[v1.generation.requires]

--- a/bottlerocket-settings-models/settings-extensions/image-verifier-plugins/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/image-verifier-plugins/src/lib.rs
@@ -1,0 +1,137 @@
+//! Settings related to Image Verifier Plugins
+
+use bottlerocket_model_derive::model;
+use bottlerocket_modeled_types::ValidBase64;
+use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use std::convert::Infallible;
+
+#[model(impl_default = true)]
+pub struct ImageVerifierPluginsSettingsV1 {
+    enabled: bool,
+    notation: NotationSettings,
+}
+
+#[model(impl_default = true)]
+pub struct NotationSettings {
+    /// Base64 encoded trustpolicy.json
+    /// https://github.com/notaryproject/specifications/blob/main/specs/trust-store-trust-policy.md#trust-store
+    trustpolicy: ValidBase64,
+}
+
+type Result<T> = std::result::Result<T, Infallible>;
+
+impl SettingsModel for ImageVerifierPluginsSettingsV1 {
+    type PartialKind = Self;
+    type ErrorKind = Infallible;
+
+    fn get_version() -> &'static str {
+        "v1"
+    }
+
+    fn set(_current_value: Option<Self>, _target: Self) -> Result<()> {
+        // Set anything that can be parsed as ImageVerifierPluginsSettingsV1.
+        Ok(())
+    }
+
+    fn generate(
+        existing_partial: Option<Self::PartialKind>,
+        _dependent_settings: Option<serde_json::Value>,
+    ) -> Result<GenerateResult<Self::PartialKind, Self>> {
+        Ok(GenerateResult::Complete(
+            existing_partial.unwrap_or_default(),
+        ))
+    }
+
+    fn validate(_value: Self, _validated_settings: Option<serde_json::Value>) -> Result<()> {
+        // ImageVerifierPluginsSettingsV1 is validated during deserialization.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_generate_image_verifier_plugins_settings() {
+        assert_eq!(
+            ImageVerifierPluginsSettingsV1::generate(None, None),
+            Ok(GenerateResult::Complete(ImageVerifierPluginsSettingsV1 {
+                enabled: None,
+                notation: None
+            }))
+        )
+    }
+
+    #[test]
+    fn test_serde_image_verifier_plugins() {
+        let test_json = json!({
+            "enabled": true,
+            "notation": {
+                "trustpolicy": "ewogICJ2ZXJzaW9uIjogIjEuMCIsCiAgInRydXN0UG9saWNpZXMiOiBbXQp9"
+            }
+        });
+
+        let test_json_str = test_json.to_string();
+
+        let image_verifier_plugins_settings: ImageVerifierPluginsSettingsV1 =
+            serde_json::from_str(&test_json_str).unwrap();
+
+        assert_eq!(image_verifier_plugins_settings.enabled, Some(true));
+        assert_eq!(
+            image_verifier_plugins_settings
+                .notation
+                .as_ref()
+                .unwrap()
+                .trustpolicy
+                .as_ref()
+                .unwrap()
+                .as_ref(),
+            "ewogICJ2ZXJzaW9uIjogIjEuMCIsCiAgInRydXN0UG9saWNpZXMiOiBbXQp9"
+        );
+    }
+
+    #[test]
+    fn test_serde_image_verifier_plugins_empty() {
+        let test_json = json!({});
+
+        let test_json_str = test_json.to_string();
+
+        let image_verifier_plugins_settings: ImageVerifierPluginsSettingsV1 =
+            serde_json::from_str(&test_json_str).unwrap();
+
+        assert!(image_verifier_plugins_settings.enabled.is_none());
+        assert!(image_verifier_plugins_settings.notation.is_none());
+    }
+
+    #[test]
+    fn test_serde_image_verifier_plugins_enabled_only() {
+        let test_json = json!({
+            "enabled": false
+        });
+
+        let test_json_str = test_json.to_string();
+
+        let image_verifier_plugins_settings: ImageVerifierPluginsSettingsV1 =
+            serde_json::from_str(&test_json_str).unwrap();
+
+        assert_eq!(image_verifier_plugins_settings.enabled, Some(false));
+        assert!(image_verifier_plugins_settings.notation.is_none());
+    }
+
+    #[test]
+    fn test_serde_image_verifier_plugins_invalid_base64() {
+        let test_json = json!({
+            "notation": {
+                "trustpolicy": "invalid-base64!"
+            }
+        });
+
+        let test_json_str = test_json.to_string();
+
+        let result = serde_json::from_str::<ImageVerifierPluginsSettingsV1>(&test_json_str);
+
+        assert!(result.is_err());
+    }
+}

--- a/bottlerocket-settings-models/settings-extensions/image-verifier-plugins/src/main.rs
+++ b/bottlerocket-settings-models/settings-extensions/image-verifier-plugins/src/main.rs
@@ -1,0 +1,20 @@
+use bottlerocket_settings_sdk::{BottlerocketSetting, NullMigratorExtensionBuilder};
+use settings_extension_image_verifier_plugins::ImageVerifierPluginsSettingsV1;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    env_logger::init();
+
+    match NullMigratorExtensionBuilder::with_name("image-verifier-plugins")
+        .with_models(vec![
+            BottlerocketSetting::<ImageVerifierPluginsSettingsV1>::model(),
+        ])
+        .build()
+    {
+        Ok(extension) => extension.run(),
+        Err(e) => {
+            println!("{e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/bottlerocket-settings-models/settings-models/Cargo.toml
+++ b/bottlerocket-settings-models/settings-models/Cargo.toml
@@ -33,6 +33,7 @@ settings-extension-container-runtime-plugins.workspace = true
 settings-extension-dns.workspace = true
 settings-extension-ecs.workspace = true
 settings-extension-host-containers.workspace = true
+settings-extension-image-verifier-plugins.workspace = true
 settings-extension-kernel.workspace = true
 settings-extension-kubernetes.workspace = true
 settings-extension-kubelet-device-plugins.workspace = true

--- a/bottlerocket-settings-models/settings-models/src/lib.rs
+++ b/bottlerocket-settings-models/settings-models/src/lib.rs
@@ -36,6 +36,7 @@ pub use settings_extension_container_runtime_plugins::{self, ContainerRuntimePlu
 pub use settings_extension_dns::{self, DnsSettingsV1};
 pub use settings_extension_ecs::{self, ECSSettingsV1};
 pub use settings_extension_host_containers::{self, HostContainersSettingsV1};
+pub use settings_extension_image_verifier_plugins::{self, ImageVerifierPluginsSettingsV1};
 pub use settings_extension_kernel::{self, KernelSettingsV1};
 pub use settings_extension_kubelet_device_plugins::{self, KubeletDevicePluginsV1};
 pub use settings_extension_kubernetes::{self, KubernetesSettingsV1};


### PR DESCRIPTION


*Issue #, if available:*

Related: https://github.com/bottlerocket-os/bottlerocket/issues/4684

*Description of changes:*

Add basic setting for an image verification plugin that configures the notation CLI with a [trustpolicy](https://github.com/notaryproject/specifications/blob/main/specs/trust-store-trust-policy.md#trust-store). The setting accepts a base64 encoded trustpolicy.json to be decoded and written to notation's configuration.

*Testing:*

Built a dev variant with the setting modeled and user data configured to set `[settings.image-verifier-plugins.notation.trustpolicy]`:

```
bash-5.1# apiclient get settings.image-ver
{
  "settings": {
    "image-verifier-plugins": {
      "notation": {
        "trustpolicy": "ewogICJ2ZXJzaW9uIjogIjEuMCIsCiAgInRydXN0UG9saWNpZXMiOiBbXQp9"
      }
    }
  }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
