### PR TITLE
feat: make image verifer plugins extensible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ serde_json = "1"
 serde_plain = "1"
 snafu = "0.8"
 syn = { version = "2", default-features = false }
+test-case = "3"
 toml = "0.8"
 tracing = "0.1"
 url = "2"

--- a/bottlerocket-settings-models/modeled-types/Cargo.toml
+++ b/bottlerocket-settings-models/modeled-types/Cargo.toml
@@ -20,7 +20,7 @@ indexmap = { workspace = true, features = ["serde"] }
 lazy_static.workspace = true
 regex.workspace = true
 semver.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_plain.workspace = true
 snafu.workspace = true

--- a/bottlerocket-settings-models/modeled-types/src/lib.rs
+++ b/bottlerocket-settings-models/modeled-types/src/lib.rs
@@ -24,6 +24,9 @@ pub mod error {
         #[snafu(display("Invalid base64 input: {}", source))]
         InvalidBase64 { source: base64::DecodeError },
 
+        #[snafu(display("Invalid JSON: {}", source))]
+        InvalidJson { source: serde_json::Error },
+
         #[snafu(display(
             "Identifiers may only contain ASCII alphanumerics plus hyphens, received '{}'",
             input

--- a/bottlerocket-settings-models/modeled-types/src/shared.rs
+++ b/bottlerocket-settings-models/modeled-types/src/shared.rs
@@ -65,6 +65,60 @@ mod test_valid_base64 {
 
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
+/// ValidBase64Json can only be created by deserializing from valid base64 text that decodes to
+/// valid JSON. It stores the original base64 text, not the decoded form. Its purpose is input
+/// validation for base64-encoded JSON configuration.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct ValidBase64Json {
+    inner: String,
+}
+
+impl TryFrom<&str> for ValidBase64Json {
+    type Error = error::Error;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(input)
+            .context(error::InvalidBase64Snafu)?;
+        serde_json::from_slice::<serde_json::Value>(&decoded).context(error::InvalidJsonSnafu)?;
+        Ok(ValidBase64Json {
+            inner: input.to_string(),
+        })
+    }
+}
+
+string_impls_for!(ValidBase64Json, "ValidBase64Json");
+
+#[cfg(test)]
+mod test_valid_base64_json {
+    use super::ValidBase64Json;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn valid_base64_json() {
+        let v = ValidBase64Json::try_from("eyJ0ZXN0IjoidmFsdWUifQ==").unwrap();
+        assert_eq!(v.as_ref(), "eyJ0ZXN0IjoidmFsdWUifQ==");
+        assert!(ValidBase64Json::try_from("e30=").is_ok());
+    }
+
+    #[test]
+    fn invalid_base64() {
+        assert!(ValidBase64Json::try_from("not base64!").is_err());
+    }
+
+    #[test]
+    fn valid_base64_invalid_json() {
+        assert!(ValidBase64Json::try_from("bm90IGpzb24=").is_err());
+    }
+
+    #[test]
+    fn empty_string() {
+        assert!(ValidBase64Json::try_from("").is_err());
+    }
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
 /// SingleLineString can only be created by deserializing from a string that contains at most one
 /// line.  It stores the original form and makes it accessible through standard traits.  Its
 /// purpose is input validation, for example in cases where you want to accept input for a

--- a/bottlerocket-settings-models/settings-extensions/image-verifier-plugins/Cargo.toml
+++ b/bottlerocket-settings-models/settings-extensions/image-verifier-plugins/Cargo.toml
@@ -14,5 +14,8 @@ env_logger.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 
+[dev-dependencies]
+test-case.workspace = true
+
 [lints]
 workspace = true

--- a/bottlerocket-settings-models/settings-extensions/image-verifier-plugins/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/image-verifier-plugins/src/lib.rs
@@ -1,21 +1,26 @@
 //! Settings related to Image Verifier Plugins
 
 use bottlerocket_model_derive::model;
-use bottlerocket_modeled_types::ValidBase64;
+use bottlerocket_modeled_types::{Identifier, ValidBase64Json};
 use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::convert::Infallible;
 
-#[model(impl_default = true)]
+/// Settings for image verifier plugins
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ImageVerifierPluginsSettingsV1 {
-    enabled: bool,
-    notation: NotationSettings,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(flatten)]
+    pub plugins: HashMap<Identifier, VerifierPluginConfig>,
 }
 
+/// Configuration for a verifier plugin
 #[model(impl_default = true)]
-pub struct NotationSettings {
-    /// Base64 encoded trustpolicy.json
-    /// https://github.com/notaryproject/specifications/blob/main/specs/trust-store-trust-policy.md#trust-store
-    trustpolicy: ValidBase64,
+pub struct VerifierPluginConfig {
+    #[serde(alias = "trust-policy", skip_serializing_if = "Option::is_none")]
+    trustpolicy: ValidBase64Json,
 }
 
 type Result<T> = std::result::Result<T, Infallible>;
@@ -52,6 +57,10 @@ impl SettingsModel for ImageVerifierPluginsSettingsV1 {
 mod test {
     use super::*;
     use serde_json::json;
+    const NOTATION_POLICY: &str = "ewogICJ2ZXJzaW9uIjogIjEuMCIsCiAgInRydXN0UG9saWNpZXMiOiBbXQp9";
+
+    use std::convert::TryInto;
+    use test_case::test_case;
 
     #[test]
     fn test_generate_image_verifier_plugins_settings() {
@@ -59,79 +68,62 @@ mod test {
             ImageVerifierPluginsSettingsV1::generate(None, None),
             Ok(GenerateResult::Complete(ImageVerifierPluginsSettingsV1 {
                 enabled: None,
-                notation: None
+                plugins: HashMap::new()
             }))
         )
     }
 
+    #[test_case(json!({}), None, &[] ; "empty object")]
+    #[test_case(json!({"enabled": false}), Some(false), &[] ; "enabled only")]
+    #[test_case(json!({"enabled": true, "notation": {"trustpolicy": NOTATION_POLICY}}), Some(true), &[("notation", NOTATION_POLICY)] ; "single plugin")]
+    #[test_case(json!({"notation": {"trustpolicy": NOTATION_POLICY}, "digestion": {"trustpolicy": "e30="}}), None, &[("notation", NOTATION_POLICY), ("digestion", "e30=")] ; "multiple plugins")]
+    #[test_case(json!({"notation": {"trust-policy": NOTATION_POLICY}}), None, &[("notation", NOTATION_POLICY)] ; "trust-policy alias")]
+    fn test_serde_image_verifier_plugins(
+        input: serde_json::Value,
+        expected_enabled: Option<bool>,
+        expected_policies: &[(&str, &str)],
+    ) {
+        let settings: ImageVerifierPluginsSettingsV1 = serde_json::from_value(input).unwrap();
+        assert_eq!(settings.enabled, expected_enabled);
+        assert_eq!(settings.plugins.len(), expected_policies.len());
+        for (plugin_name, expected_policy) in expected_policies {
+            let key: Identifier = (*plugin_name).try_into().unwrap();
+            let plugin = settings.plugins.get(&key).expect(plugin_name);
+            assert_eq!(
+                plugin.trustpolicy.as_ref().unwrap().as_ref(),
+                *expected_policy
+            );
+        }
+    }
+
+    #[test_case(json!({"notation": {"trustpolicy": "invalid-base64!"}}) ; "invalid base64")]
+    #[test_case(json!({"notation": {"trustpolicy": "bm90IGpzb24="}}) ; "invalid json in base64")]
+    fn test_serde_invalid_trustpolicy(input: serde_json::Value) {
+        assert!(serde_json::from_value::<ImageVerifierPluginsSettingsV1>(input).is_err());
+    }
+
     #[test]
-    fn test_serde_image_verifier_plugins() {
-        let test_json = json!({
-            "enabled": true,
-            "notation": {
-                "trustpolicy": "ewogICJ2ZXJzaW9uIjogIjEuMCIsCiAgInRydXN0UG9saWNpZXMiOiBbXQp9"
-            }
-        });
-
-        let test_json_str = test_json.to_string();
-
-        let image_verifier_plugins_settings: ImageVerifierPluginsSettingsV1 =
-            serde_json::from_str(&test_json_str).unwrap();
-
-        assert_eq!(image_verifier_plugins_settings.enabled, Some(true));
+    fn test_default_serialization_is_empty() {
+        let settings = ImageVerifierPluginsSettingsV1::default();
+        let json = serde_json::to_value(&settings).unwrap();
         assert_eq!(
-            image_verifier_plugins_settings
-                .notation
-                .as_ref()
-                .unwrap()
-                .trustpolicy
-                .as_ref()
-                .unwrap()
-                .as_ref(),
-            "ewogICJ2ZXJzaW9uIjogIjEuMCIsCiAgInRydXN0UG9saWNpZXMiOiBbXQp9"
+            json,
+            json!({}),
+            "default settings should serialize to empty object"
         );
     }
 
     #[test]
-    fn test_serde_image_verifier_plugins_empty() {
-        let test_json = json!({});
-
-        let test_json_str = test_json.to_string();
-
-        let image_verifier_plugins_settings: ImageVerifierPluginsSettingsV1 =
-            serde_json::from_str(&test_json_str).unwrap();
-
-        assert!(image_verifier_plugins_settings.enabled.is_none());
-        assert!(image_verifier_plugins_settings.notation.is_none());
-    }
-
-    #[test]
-    fn test_serde_image_verifier_plugins_enabled_only() {
-        let test_json = json!({
-            "enabled": false
-        });
-
-        let test_json_str = test_json.to_string();
-
-        let image_verifier_plugins_settings: ImageVerifierPluginsSettingsV1 =
-            serde_json::from_str(&test_json_str).unwrap();
-
-        assert_eq!(image_verifier_plugins_settings.enabled, Some(false));
-        assert!(image_verifier_plugins_settings.notation.is_none());
-    }
-
-    #[test]
-    fn test_serde_image_verifier_plugins_invalid_base64() {
-        let test_json = json!({
-            "notation": {
-                "trustpolicy": "invalid-base64!"
-            }
-        });
-
-        let test_json_str = test_json.to_string();
-
-        let result = serde_json::from_str::<ImageVerifierPluginsSettingsV1>(&test_json_str);
-
-        assert!(result.is_err());
+    fn test_plugin_with_no_trustpolicy_omits_null() {
+        // A plugin registered without a trust policy should serialize
+        // without a "trustpolicy": null entry.
+        let input = json!({"notation": {}});
+        let settings: ImageVerifierPluginsSettingsV1 = serde_json::from_value(input).unwrap();
+        let output = serde_json::to_value(&settings).unwrap();
+        assert_eq!(
+            output,
+            json!({"notation": {}}),
+            "plugin with no trustpolicy should not serialize null fields"
+        );
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/4684

**Description of changes:**
Replace the hard-coded "notation" plugin with an extensible map. This allows additional plugins to be added by downstream builds, or at runtime by copying plugins to a host path.

Plugins can store a corresponding trust policy in the settings API, which must be a base64-encoded JSON blob. Although this is optional, registering the trust policy with the OS ensures that it is measured into the TPM2 device, making it visible for remote attestation. The JSON format ensures that the policy can be canonicalized at runtime, rather than requiring it to be provied in canonical form.

**Testing done:**

Verified that `enabled` can't be the name of a plugin:
```
bash-5.3# apiclient apply <<EOF
[settings.image-verifier-plugins.enabled]
trustpolicy = "eyJ0cnVzdGVkRGlnZXN0cyI6W119"
EOF
Failed to apply settings: Failed to PATCH settings from '-' to '/settings?tx=apiclient-apply-oUh6I9Nnfo7wmvYy': Status 400 when PATCHing /settings?tx=apiclient-apply-oUh6I9Nnfo7wmvYy: Json deserialize error: invalid type: map, expected a boolean at line 1 column 37
```

Verified that I can configure two other policies:
```
bash-5.3# apiclient apply <<EOF
[settings.image-verifier-plugins]
enabled = true

[settings.image-verifier-plugins.digestion]
trustpolicy = "..."

[settings.image-verifier-plugins.notation]
trustpolicy = "..."
EOF

bash-5.3# apiclient get settings.image-verifier-plugins
{
  "settings": {
    "image-verifier-plugins": {
      "digestion": {
        "trustpolicy": "..."
      },
      "enabled": true,
      "notation": {
        "trustpolicy": "..."
      }
    }
  }
```

**Terms of contribution:**
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
