### PR TITLE
feat(network): add disable_ipv6 setting to NetworkSettingsV1

### DIFF
--- a/bottlerocket-settings-models/settings-extensions/network/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/network/src/lib.rs
@@ -10,6 +10,7 @@ struct NetworkSettingsV1 {
     hosts: EtcHostsEntries,
     https_proxy: Url,
     no_proxy: Vec<SingleLineString>,
+    disable_ipv6: Vec<SingleLineString>,
 }
 
 type Result<T> = std::result::Result<T, Infallible>;
@@ -55,6 +56,7 @@ mod test {
                 hosts: None,
                 https_proxy: None,
                 no_proxy: None,
+                disable_ipv6: None,
             }))
         )
     }
@@ -80,7 +82,36 @@ mod test {
                 ),
                 https_proxy: Some(Url::try_from("https://example.net").unwrap()),
                 no_proxy: Some(vec![SingleLineString::try_from("foo").unwrap()]),
+                disable_ipv6: None,
             }
         );
+    }
+
+    #[test]
+    fn test_serde_network_with_disable_ipv6() {
+        let test_json = r#"{
+            "disable-ipv6": ["eth0", "eth1"]
+        }"#;
+
+        let network: NetworkSettingsV1 = serde_json::from_str(test_json).unwrap();
+
+        assert_eq!(
+            network,
+            NetworkSettingsV1 {
+                hostname: None,
+                hosts: None,
+                https_proxy: None,
+                no_proxy: None,
+                disable_ipv6: Some(vec![
+                    SingleLineString::try_from("eth0").unwrap(),
+                    SingleLineString::try_from("eth1").unwrap(),
+                ]),
+            }
+        );
+
+        // Round-trip
+        let serialized = serde_json::to_string(&network).unwrap();
+        let deserialized: NetworkSettingsV1 = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(network, deserialized);
     }
 }


### PR DESCRIPTION
Issue #, if available:
https://github.com/bottlerocket-os/bottlerocket/issues/4752

Description of changes:

Add disable_ipv6 field to NetworkSettingsV1 as Vec<SingleLineString>, accepting a list of interface names on which to disable IPv6.

This is part of a broader change to add settings.network.disable-ipv6. The corresponding netdog and bottlerocket-os changes render a systemd-networkd drop-in (20-disable-ipv6.conf) that sets LinkLocalAddressing=ipv4 and 
IPv6AcceptRA=false for each listed interface.

Testing done:

I have a draft PR in core-kit that pulls this setting and render the drop-in network file for the desired interface with proper ipv6 disabling - https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/826/changes#diff-6fdaca693458bdb59e43b491eefa0112cca863f59d9dbf3a319424357ca6da09

- Serde round-trip unit tests pass for the new field
- Full end-to-end test:
 built aws-k8s-1.34 with this change, launched an instance with below userdata:
 ```toml
  [settings.network]
  disable-ipv6 = ["eth0"]
 ```
 Confirmed the drop-in renders correctly:
 
```shell
  bash-5.2# cat /etc/systemd/network/10-eth0.network.d/20-disable-ipv6.conf
  [Network]
  LinkLocalAddressing=ipv4
  IPv6AcceptRA=false
```  

 Confirmed eth0 has no IPv6 link-local addresses:
 
```shell
  bash-5.2#  ip -6 addr show dev eth0
  (no output)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.