### PR TITLE
feat(container-runtime): add max-concurrent-unpacks setting

### DIFF
--- a/bottlerocket-settings-models/CHANGELOG.md
+++ b/bottlerocket-settings-models/CHANGELOG.md
@@ -11,15 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [unreleased changes here]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/compare/bottlerocket-settings-models-v0.22.0...HEAD
 
-## [0.22.0] - 2026-04-01
+## [0.22.0] - 2026-04-02
 
 ## Model Changes
 
 ### Added
 
 - Add support for  `prefer-closest-numa-nodes` and `max-allowable-numa-nodes` in Kubernetes' Topology Manager Policy options ([#117])
+- Added `container-runtime.max-concurrent-unpacks` setting for containerd 2.2 parallel unpack support ([#119])
 
 [#117]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/117
+[#119]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/119
 
 [0.22.0]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/compare/bottlerocket-settings-models-v0.21.0...bottlerocket-settings-models-v0.22.0
 

--- a/bottlerocket-settings-models/settings-extensions/container-runtime/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/container-runtime/src/lib.rs
@@ -9,6 +9,7 @@ use std::convert::Infallible;
 pub struct ContainerRuntimeSettingsV1 {
     max_container_log_line_size: i32,
     max_concurrent_downloads: i32,
+    max_concurrent_unpacks: i32,
     #[serde(
         alias = "concurrent-layer-fetch-buffer",
         default,
@@ -71,6 +72,7 @@ mod test {
             Ok(GenerateResult::Complete(ContainerRuntimeSettingsV1 {
                 max_container_log_line_size: None,
                 max_concurrent_downloads: None,
+                max_concurrent_unpacks: None,
                 concurrent_download_chunk_size: None,
                 enable_unprivileged_ports: None,
                 enable_unprivileged_icmp: None,
@@ -84,6 +86,7 @@ mod test {
         let test_json = json!({
             "max-container-log-line-size": 1024,
             "max-concurrent-downloads": 5,
+            "max-concurrent-unpacks": 5,
             "concurrent-download-chunk-size": "64mb",
             "enable-unprivileged-ports": true,
             "enable-unprivileged-icmp": false,
@@ -100,6 +103,7 @@ mod test {
             ContainerRuntimeSettingsV1 {
                 max_container_log_line_size: Some(1024),
                 max_concurrent_downloads: Some(5),
+                max_concurrent_unpacks: Some(5),
                 concurrent_download_chunk_size: Some(64000000), // 64mb in bytes
                 enable_unprivileged_ports: Some(true),
                 enable_unprivileged_icmp: Some(false),
@@ -114,6 +118,7 @@ mod test {
         let expected_json = json!({
             "max-container-log-line-size": 1024,
             "max-concurrent-downloads": 5,
+            "max-concurrent-unpacks": 5,
             "concurrent-download-chunk-size": 64000000, // Serialized as number
             "enable-unprivileged-ports": true,
             "enable-unprivileged-icmp": false,
@@ -128,6 +133,7 @@ mod test {
         let test_json = json!({
             "max-container-log-line-size": 2048,
             "max-concurrent-downloads": 10,
+            "max-concurrent-unpacks": 3,
             "concurrent-layer-fetch-buffer": "128mb",
             "enable-unprivileged-ports": false,
             "enable-unprivileged-icmp": true,
@@ -142,6 +148,7 @@ mod test {
             ContainerRuntimeSettingsV1 {
                 max_container_log_line_size: Some(2048),
                 max_concurrent_downloads: Some(10),
+                max_concurrent_unpacks: Some(3),
                 concurrent_download_chunk_size: Some(128000000), // 128mb in bytes
                 enable_unprivileged_ports: Some(false),
                 enable_unprivileged_icmp: Some(true),


### PR DESCRIPTION
*Issue #, if available:*
Related - https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/806

*Description of changes:*
Add new setting `container-runtime.max-concurrent-unpacks`.  Containerd 2.2 supports parallel unpack now (see https://github.com/containerd/containerd/pull/12332). 

Adding the setting to expose that configuration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
