### PR TITLE
Revert toml snafu bumps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ serde_plain = "1"
 snafu = "0.9"
 syn = { version = "2", default-features = false }
 test-case = "3"
-toml = "1.1"
+toml = "0.8"
 tracing = "0.1"
 url = "2"
 walkdir = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ semver = "1"
 serde = "1"
 serde_json = "1"
 serde_plain = "1"
-snafu = "0.9"
+snafu = "0.8"
 syn = { version = "2", default-features = false }
 test-case = "3"
 toml = "0.8"


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Reverts the dependabot bumps for `toml` (0.8 → 1.1, PR #126) and `snafu` (0.8 → 0.9, PR #125) that were included in the v0.22.0 release.

These version bumps carry breaking API changes that are too risky to ship alongside the new settings work:

**toml 1.1** ([changelog](https://github.com/toml-rs/toml/blob/main/crates/toml/CHANGELOG.md#compatibility-2)):
- `Serializer::new` / `Serializer::pretty` now take `&mut Buffer` instead of `&mut String`
- `from_str`, `Deserializer` etc no longer preserve order without `preserve_order` feature
- `impl FromStr for Value` now parses TOML values, not documents
- Entirely new TOML parser and writer underneath (regression risk)
- MSRV bumped to 1.85

**snafu 0.9** ([changelog](https://github.com/shepmaster/snafu/blob/main/CHANGELOG.md)):
- `Whatever` now requires `Send + Sync` on wrapped errors
- Opaque errors default to `Into` conversion instead of exact type matching
- `Error::description` and `Error::cause` no longer generated

Bottlerocket uses both crates extensively across core-kit. These bumps need a dedicated effort with proper codebase-wide analysis rather than being bundled with feature work.

The safe bumps (x509-parser 0.16 → 0.18, ctor 0.2 → 0.3) and all feature work (containerd 2.2 `max-concurrent-unpacks`, `TopologyManagerPolicyOptions`) are preserved.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
