### PR TITLE
chore: bump settings-models to 0.23.0

### DIFF
--- a/bottlerocket-settings-models/CHANGELOG.md
+++ b/bottlerocket-settings-models/CHANGELOG.md
@@ -9,7 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - See [unreleased changes here]
 
-[unreleased changes here]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/compare/bottlerocket-settings-models-v0.22.0...HEAD
+[unreleased changes here]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/compare/bottlerocket-settings-models-v0.23.0...HEAD
+
+## [0.23.0] - 2026-04-06
+
+### Changed
+
+- Reverted `toml` dependency from 1.1 back to 0.8
+- Reverted `snafu` dependency from 0.9 back to 0.8
+
+[0.23.0]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/compare/bottlerocket-settings-models-v0.22.0...bottlerocket-settings-models-v0.23.0
 
 ## [0.22.0] - 2026-04-02
 

--- a/bottlerocket-settings-models/settings-models/Cargo.toml
+++ b/bottlerocket-settings-models/settings-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bottlerocket-settings-models"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Tom Kirchner <tjk@amazon.com>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Release 0.23.0 with the deps revert.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
