### PR TITLE
feat(container-registry): add configurable capabilities to RegistryMi…

### DIFF
--- a/bottlerocket-settings-models/CHANGELOG.md
+++ b/bottlerocket-settings-models/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- See [unreleased changes here]
+## Model Changes
+
+### Added
+
+- Added `RegistryMirrorCapabilityV1` enum (`pull`, `resolve`, `push`) and optional `capabilities` field to `RegistryMirrorV1`, allowing per-mirror capability configuration for containerd registry mirrors
 
 [unreleased changes here]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/compare/bottlerocket-settings-models-v0.23.0...HEAD
 

--- a/bottlerocket-settings-models/settings-extensions/container-registry/src/de.rs
+++ b/bottlerocket-settings-models/settings-extensions/container-registry/src/de.rs
@@ -38,6 +38,7 @@ where
                 vec.push(RegistryMirrorV1 {
                     registry: Some(k),
                     endpoint: Some(v),
+                    capabilities: None,
                 });
             }
             Ok(Some(vec))

--- a/bottlerocket-settings-models/settings-extensions/container-registry/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/container-registry/src/lib.rs
@@ -7,12 +7,24 @@ use crate::de::deserialize_mirrors;
 use bottlerocket_model_derive::model;
 use bottlerocket_modeled_types::{SingleLineString, Url, ValidBase64};
 use bottlerocket_settings_sdk::{GenerateResult, SettingsModel};
+use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
+
+/// Operations a registry mirror endpoint can perform.
+/// Maps directly to containerd's hosts.toml capability values.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RegistryMirrorCapabilityV1 {
+    Pull,
+    Resolve,
+    Push,
+}
 
 #[model(impl_default = true)]
 struct RegistryMirrorV1 {
     registry: SingleLineString,
     endpoint: Vec<Url>,
+    capabilities: Vec<RegistryMirrorCapabilityV1>,
 }
 
 #[model(impl_default = true)]
@@ -125,5 +137,40 @@ mod test {
         assert!(credentials.first().unwrap().username.is_none());
         assert!(credentials.first().unwrap().password.is_none());
         assert!(credentials.first().unwrap().identitytoken.is_none());
+    }
+
+    #[test]
+    fn test_serde_mirror_with_capabilities() {
+        let test_json = r#"{
+            "mirrors": [
+                {
+                    "registry": "docker.io",
+                    "endpoint": ["https://example.net"],
+                    "capabilities": ["pull"]
+                }
+            ]
+        }"#;
+        let settings: RegistrySettingsV1 = serde_json::from_str(test_json).unwrap();
+        let mirrors = settings.mirrors.unwrap();
+        let caps = mirrors.first().unwrap().capabilities.clone().unwrap();
+        assert_eq!(caps, vec![RegistryMirrorCapabilityV1::Pull]);
+    }
+
+    #[test]
+    fn test_serde_mirror_without_capabilities_is_none() {
+        let test_json = r#"{"mirrors": [{"registry": "foo", "endpoint": ["https://example.net"]}]}"#;
+        let settings: RegistrySettingsV1 = serde_json::from_str(test_json).unwrap();
+        let mirrors = settings.mirrors.unwrap();
+        assert!(mirrors.first().unwrap().capabilities.is_none());
+    }
+
+    #[test]
+    fn test_serde_mirror_unknown_capability_rejected() {
+        let test_json = r#"{
+            "mirrors": [
+                {"registry": "foo", "endpoint": ["https://example.net"], "capabilities": ["fly"]}
+            ]
+        }"#;
+        assert!(serde_json::from_str::<RegistrySettingsV1>(test_json).is_err());
     }
 }


### PR DESCRIPTION
## Summary

Adds `RegistryMirrorCapabilityV1` enum (`pull`, `resolve`, `push`) and an optional `capabilities` field to `RegistryMirrorV1`, enabling per-mirror capability configuration for containerd registry mirrors.

Previously, consumers of this model (e.g. `thar-be-registries` in `bottlerocket-core-kit`) had to hardcode capabilities for all mirrors. This blocked tools like [Spegel](https://github.com/spegel-org/spegel) that require `pull`-only mirrors. containerd 2.1's transfer service fails when Spegel's DHT hasn't initialized if `resolve` is also requested.

When `capabilities` is absent, consumers default to `["pull", "resolve"]` for backward compatibility. Unknown values are rejected at serde deserialization time.

A companion PR in `bottlerocket-core-kit` updates `thar-be-registries` and the registry template to read and emit this field.

## Related Issues

- Closes #133
- See also: bottlerocket-os/bottlerocket#4710

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
