### PR TITLE
feat: k8s: add container-runtime-endpoint setting

### DIFF
--- a/bottlerocket-settings-models/settings-extensions/kubernetes/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/kubernetes/src/lib.rs
@@ -102,6 +102,7 @@ pub struct KubernetesSettingsV1 {
     hostname_override: ValidLinuxHostname,
     ids_per_pod: KubernetesIdsPerPodValue,
     max_parallel_image_pulls: i32,
+    container_runtime_endpoint: Url,
 }
 
 type Result<T> = std::result::Result<T, Infallible>;
@@ -210,6 +211,7 @@ mod test {
                 static_pods_enabled: None,
                 ids_per_pod: None,
                 max_parallel_image_pulls: None,
+                container_runtime_endpoint: None,
             })
         );
     }
@@ -232,6 +234,26 @@ mod test {
                 hostname_override_source: Some(KubernetesHostnameOverrideSource::PrivateDNSName),
                 ..Default::default()
             }
+        );
+    }
+
+    #[test]
+    fn test_serde_container_runtime_endpoint() {
+        // Backwards compatible: existing user-data that omits the field
+        // deserializes fine and the field reads back as None.
+        let without: KubernetesSettingsV1 =
+            serde_json::from_str(r#"{"cluster-name": "my-cluster"}"#).unwrap();
+        assert!(without.container_runtime_endpoint.is_none());
+
+        // Unix-socket URIs parse and round-trip losslessly, which is
+        // the intended shape for a CRI endpoint override.
+        let with: KubernetesSettingsV1 = serde_json::from_str(
+            r#"{"container-runtime-endpoint": "unix:///run/containerd/containerd.sock"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            with.container_runtime_endpoint,
+            Some("unix:///run/containerd/containerd.sock".try_into().unwrap())
         );
     }
 }

--- a/bottlerocket-settings-sdk/src/extension/proto1.rs
+++ b/bottlerocket-settings-sdk/src/extension/proto1.rs
@@ -22,7 +22,7 @@ use tracing::instrument;
 pub fn run_extension<P: Proto1>(extension: P, cmd: Proto1Command) -> ExitCode {
     match try_run_extension(extension, cmd) {
         Ok(output) => {
-            println!("{}", &output);
+            println!("{output}");
             ExitCode::SUCCESS
         }
         Err(e) => {


### PR DESCRIPTION
Add `settings.kubernetes.container-runtime-endpoint` so the CRI socket kubelet talks to can be configured via user-data instead of being fixed to `unix:///run/containerd/containerd.sock`.

*Issue #, if available:*

*Description of changes:*


- Added `container_runtime_endpoint: Url` to `KubernetesSettingsV1`. Field is optional (defaults to `None`) so existing user-data and datastore contents are unaffected.
- Extended `test_generate_kubernetes` to include the new default.
- Added `test_serde_container_runtime_endpoint` covering (a) omitted-field round-trip (backwards compatibility) and (b) `unix:///…` value parsing through the `Url` newtype.


*Testing*
```
cargo test 2>&1 | tail -20

test test::test_serde_container_runtime_endpoint ... ok
test test::test_serde_kubernetes ... ok
test de::node_taint_tests::node_taint_empty_list ... ok
test de::node_taint_tests::node_taints_list_representation ... ok
test de::node_taint_tests::node_taint_single_representation ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
