### PR TITLE
feat: ntp: add refclock and chrony access settings

### DIFF
--- a/bottlerocket-settings-models/settings-extensions/ntp/src/lib.rs
+++ b/bottlerocket-settings-models/settings-extensions/ntp/src/lib.rs
@@ -1,14 +1,57 @@
 //! The ntp settings can be used to specify time servers with which to synchronize the instance's
-//! clock.
+//! clock. They can also be used to point chrony at hardware or software reference clocks (such as
+//! a PTP hardware clock) and to grant remote access to the chrony daemon.
 use bottlerocket_model_derive::model;
-use bottlerocket_modeled_types::Url;
+use bottlerocket_modeled_types::{SingleLineString, Url};
 use bottlerocket_settings_sdk::{GenerateResult, LinearlyMigrateable, NoMigration, SettingsModel};
+use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 
 #[model(impl_default = true)]
 pub struct NtpSettingsV1 {
     time_servers: Vec<Url>,
     options: Vec<String>,
+    refclocks: Vec<NtpRefClock>,
+    allow: Vec<SingleLineString>,
+    cmdallow: Vec<SingleLineString>,
+    // chrony's `bindcmdaddress` accepts either an IP address or a Unix domain socket path (e.g.
+    // `/run/chrony/chronyd.sock`), so this is a single-line string rather than an `IpAddr`.
+    bindcmdaddress: Vec<SingleLineString>,
+}
+
+/// A hardware or software reference clock that chrony can use as a time source.
+///
+/// This maps directly to chrony's `refclock` directive:
+/// `refclock <driver> <parameter> [<option>...]`
+///
+/// For example, to use the PTP hardware clock exposed by the Amazon ENA driver, the following
+/// chrony configuration:
+///
+/// `refclock PHC /dev/ptp_ena poll 0 delay 0.000010 prefer`
+///
+/// is expressed as:
+///
+/// ```text
+/// [[settings.ntp.refclocks]]
+/// driver = "PHC"
+/// parameter = "/dev/ptp_ena"
+/// options = ["poll", "0", "delay", "0.000010", "prefer"]
+/// ```
+//
+// This is intentionally not a `#[model]` struct: because refclocks are stored as a single list
+// value in the datastore (rather than exploded into individual keys), the fields can be required
+// rather than optional, letting deserialization reject a refclock that is missing its driver or
+// parameter.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct NtpRefClock {
+    /// The refclock driver name, e.g. `PHC`.
+    pub driver: SingleLineString,
+    /// The driver-specific parameter, e.g. the device path `/dev/ptp_ena`.
+    pub parameter: SingleLineString,
+    /// Additional refclock options, e.g. `["poll", "0", "delay", "0.000010", "prefer"]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub options: Vec<SingleLineString>,
 }
 
 type Result<T> = std::result::Result<T, Infallible>;
@@ -67,6 +110,10 @@ mod test {
             Ok(GenerateResult::Complete(NtpSettingsV1 {
                 time_servers: None,
                 options: None,
+                refclocks: None,
+                allow: None,
+                cmdallow: None,
+                bindcmdaddress: None,
             }))
         )
     }
@@ -100,5 +147,104 @@ mod test {
 
         let results = serde_json::to_string(&ntp).unwrap();
         assert_eq!(results, test_json);
+    }
+
+    #[test]
+    fn test_refclocks_ntp() {
+        // A refclock matching the AWS PTP hardware clock example:
+        // `refclock PHC /dev/ptp_ena poll 0 delay 0.000010 prefer`
+        let test_json = r#"{"refclocks":[{"driver":"PHC","parameter":"/dev/ptp_ena","options":["poll","0","delay","0.000010","prefer"]}]}"#;
+
+        let ntp: NtpSettingsV1 = serde_json::from_str(test_json).unwrap();
+        assert_eq!(
+            ntp.refclocks.clone().unwrap(),
+            vec![NtpRefClock {
+                driver: SingleLineString::try_from("PHC").unwrap(),
+                parameter: SingleLineString::try_from("/dev/ptp_ena").unwrap(),
+                options: vec![
+                    SingleLineString::try_from("poll").unwrap(),
+                    SingleLineString::try_from("0").unwrap(),
+                    SingleLineString::try_from("delay").unwrap(),
+                    SingleLineString::try_from("0.000010").unwrap(),
+                    SingleLineString::try_from("prefer").unwrap(),
+                ],
+            }]
+        );
+
+        let results = serde_json::to_string(&ntp).unwrap();
+        assert_eq!(results, test_json);
+    }
+
+    #[test]
+    fn test_refclock_options_default_empty() {
+        // `options` is optional and defaults to an empty list when omitted.
+        let test_json = r#"{"refclocks":[{"driver":"PHC","parameter":"/dev/ptp0"}]}"#;
+
+        let ntp: NtpSettingsV1 = serde_json::from_str(test_json).unwrap();
+        assert_eq!(
+            ntp.refclocks.clone().unwrap(),
+            vec![NtpRefClock {
+                driver: SingleLineString::try_from("PHC").unwrap(),
+                parameter: SingleLineString::try_from("/dev/ptp0").unwrap(),
+                options: Vec::new(),
+            }]
+        );
+
+        // An empty options list should not be serialized back out.
+        let results = serde_json::to_string(&ntp).unwrap();
+        assert_eq!(results, test_json);
+    }
+
+    #[test]
+    fn test_refclock_requires_driver_and_parameter() {
+        // A refclock without a driver or parameter is rejected during deserialization.
+        assert!(
+            serde_json::from_str::<NtpSettingsV1>(r#"{"refclocks":[{"driver":"PHC"}]}"#).is_err()
+        );
+        assert!(serde_json::from_str::<NtpSettingsV1>(
+            r#"{"refclocks":[{"parameter":"/dev/ptp0"}]}"#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_daemon_access_ntp() {
+        // The chrony daemon access directives from the feature request:
+        // `allow`, `cmdallow`, and `bindcmdaddress`. chrony's `bindcmdaddress` accepts both IP
+        // addresses and a Unix domain socket path, so both forms are exercised here.
+        let test_json = r#"{"allow":["192.0.2.0/24"],"cmdallow":["198.51.100.0/24"],"bindcmdaddress":["10.0.0.5","/run/chrony/chronyd.sock"]}"#;
+
+        let ntp: NtpSettingsV1 = serde_json::from_str(test_json).unwrap();
+        assert_eq!(
+            ntp.allow.clone().unwrap(),
+            vec![SingleLineString::try_from("192.0.2.0/24").unwrap()]
+        );
+        assert_eq!(
+            ntp.cmdallow.clone().unwrap(),
+            vec![SingleLineString::try_from("198.51.100.0/24").unwrap()]
+        );
+        assert_eq!(
+            ntp.bindcmdaddress.clone().unwrap(),
+            vec![
+                SingleLineString::try_from("10.0.0.5").unwrap(),
+                SingleLineString::try_from("/run/chrony/chronyd.sock").unwrap(),
+            ]
+        );
+
+        let results = serde_json::to_string(&ntp).unwrap();
+        assert_eq!(results, test_json);
+    }
+
+    #[test]
+    fn test_daemon_access_rejects_line_terminator() {
+        // Values are rendered directly into chrony.conf, so a line terminator (which could inject
+        // additional directives) must be rejected.
+        assert!(serde_json::from_str::<NtpSettingsV1>(
+            "{\"bindcmdaddress\":[\"10.0.0.5\nallow all\"]}"
+        )
+        .is_err());
+        assert!(
+            serde_json::from_str::<NtpSettingsV1>("{\"allow\":[\"192.0.2.0/24\nfoo\"]}").is_err()
+        );
     }
 }


### PR DESCRIPTION
**Issue number:**
Addresses bottlerocket-os/bottlerocket#4407 and bottlerocket-os/bottlerocket#4473

**Description of changes:**
Extends `NtpSettingsV1` so chrony can be configured through the API instead of hand-editing `/etc/chrony.conf` — the approach a maintainer identified as the "correct" fix in bottlerocket-os/bottlerocket#4407.

- `settings.ntp.refclocks`: a list of reference clocks that maps to chrony's `refclock <driver> <parameter> [options...]` directive. This enables the AWS PTP hardware clock use case, e.g. `refclock PHC /dev/ptp_ena poll 0 delay 0.000010 prefer`. Modeled as a list of `{ driver, parameter, options }`; `driver` and `parameter` are required (rejected at deserialization if missing).
- `settings.ntp.allow`, `settings.ntp.cmdallow`, `settings.ntp.bindcmdaddress`: chrony daemon access directives (bottlerocket-os/bottlerocket#4473). `bindcmdaddress` accepts either an IP address or a Unix domain socket path, so these use `SingleLineString` for full directive fidelity and to prevent config-file injection.

All fields are optional and default to unset, so existing user-data and datastore contents are unaffected (backwards compatible).

This is the first of a coordinated set of changes; the chrony template that consumes these settings (bottlerocket-core-kit) and the datastore migration (bottlerocket) are in separate PRs.

**Testing:**
- `cargo test -p settings-extension-ntp` — 8 passed (serde round-trips, required-field enforcement, injection rejection, PHC/access examples)
- `cargo clippy -p settings-extension-ntp --all-targets` and `cargo fmt -p settings-extension-ntp -- --check` — clean

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
